### PR TITLE
feature: interpolate secrets in custom alerter

### DIFF
--- a/bin/core/src/alert/mod.rs
+++ b/bin/core/src/alert/mod.rs
@@ -157,7 +157,8 @@ async fn send_custom_alert(
     .await
     .map_err(|e| {
       let replacers = secret_replacers.into_iter().collect::<Vec<_>>();
-      svi::replace_in_string(&format!("{e:?}"), &replacers)
+      let sanitized_error = svi::replace_in_string(&format!("{e:?}"), &replacers);
+      anyhow::Error::msg(format!("Error with request: {}", sanitized_error))
     })
     .context("failed at post request to alerter")?;
   let status = res.status();

--- a/bin/core/src/alert/mod.rs
+++ b/bin/core/src/alert/mod.rs
@@ -155,6 +155,10 @@ async fn send_custom_alert(
     .json(alert)
     .send()
     .await
+    .map_err(|e| {
+      let replacers = secret_replacers.into_iter().collect::<Vec<_>>();
+      svi::replace_in_string(&format!("{e:?}"), &replacers)
+    })
     .context("failed at post request to alerter")?;
   let status = res.status();
   if !status.is_success() {

--- a/bin/core/src/alert/mod.rs
+++ b/bin/core/src/alert/mod.rs
@@ -140,7 +140,7 @@ async fn send_custom_alert(
   let vars_and_secrets = get_variables_and_secrets().await?;
   let mut global_replacers = HashSet::new();
   let mut secret_replacers = HashSet::new();
-  let mut url_interpolated = url.clone().into();
+  let mut url_interpolated = url.to_string();
 
   // interpolate variables and secrets into the url
   interpolate_variables_secrets_into_string(


### PR DESCRIPTION
This is something i really need, in order to be able to manage my alerters with a git sync without exposing my secrets.

I have a custom endpoint to which i add a secret token, not perfect security-wise (headers would be better) but i think it can still be an improvement for some users.

⚠️ i didn't attempt to sanitise the trace, that could be beyond my knowledge of rust and this awesome project ^^

## Screens
<img width="506" alt="Screenshot 2025-02-03 at 16 55 52" src="https://github.com/user-attachments/assets/cc14c8c1-20c4-4f3f-930d-674174fa66fd" />
<img width="715" alt="Screenshot 2025-02-03 at 16 55 46" src="https://github.com/user-attachments/assets/64a2d6ad-8756-48f5-a0c9-bff771599c5d" />

### Full URL interpolated
<img width="398" alt="Screenshot 2025-02-03 at 17 24 35" src="https://github.com/user-attachments/assets/5dff08a4-9902-43a1-8379-9fc79e2780f2" />

<img width="629" alt="Screenshot 2025-02-03 at 17 24 45" src="https://github.com/user-attachments/assets/e16e4617-74a9-4d01-8f02-41501ece9469" />

<img width="606" alt="Screenshot 2025-02-03 at 17 24 39" src="https://github.com/user-attachments/assets/29cb821e-feab-4628-b2b3-3ef9a62e24f7" />
