### PR TITLE
feature: allow docker image text to overflow in table

### DIFF
--- a/frontend/src/components/util.tsx
+++ b/frontend/src/components/util.tsx
@@ -677,7 +677,7 @@ export const DockerResourceLink = ({
       <Icon server_id={server_id} name={type === "image" ? id : name} />
       <div
         title={name}
-        className="max-w-[200px] lg:max-w-[250px] overflow-hidden overflow-ellipsis"
+        className="max-w-[250px] lg:max-w-[300px] overflow-hidden overflow-ellipsis overflow-breakable"
       >
         {name}
       </div>

--- a/frontend/src/globals.css
+++ b/frontend/src/globals.css
@@ -95,3 +95,7 @@
 .asdfa {
   color: #151b25
 }
+
+.overflow-breakable {
+  overflow-wrap: break-word;
+}


### PR DESCRIPTION
This PR attempt to fix a UI issue on mobile.

### Observations
The image of a service is being truncated and makes it unreadable on mobile : 

#### header view
<img width="287" alt="Screenshot 2025-02-07 at 10 23 18" src="https://github.com/user-attachments/assets/c7f7f7ab-ad09-4be0-a4b9-93c3f44d2116" />

#### table view
<img width="344" alt="Screenshot 2025-02-07 at 10 23 42" src="https://github.com/user-attachments/assets/991d2f87-f07d-4bfd-8cb7-279d65d23866" />


Which is kind of annoying, because you cannot see the actual image name anywhere :) 

### Proposed changes
The proposed changes can fix that, but i'm not sure it is the best approach: 

#### header view
<img width="322" alt="Screenshot 2025-02-07 at 10 24 40" src="https://github.com/user-attachments/assets/d8cb7b19-31c9-4374-9abd-67b266caf68b" />

#### table view
<img width="379" alt="Screenshot 2025-02-07 at 10 24 59" src="https://github.com/user-attachments/assets/0bba4d91-6596-48a9-b2b9-40ab7a03b05f" />



ℹ️ It was already breaking the text, but only if your image name had a `-` 