### PR TITLE
feature: update devcontainer node release

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,7 +10,7 @@
 	// Features to add to the dev container. More info: https://containers.dev/features.
 	"features": {
 		"ghcr.io/devcontainers/features/node:1": {
-			"version": "18.18.0"
+			"version": "20.12.2"
 		},
 		"ghcr.io/devcontainers-community/features/deno:1": {
 


### PR DESCRIPTION
I believe the devcontainer node release needs to be aligned with the frontend Dockerfile base image:

```
FROM node:20.12-alpine as builder
```

If not, seems like the devcontainer `Init` task is failing