### PR TITLE
feature: improve tables quick actions on mobile

### DIFF
--- a/frontend/src/pages/resources.tsx
+++ b/frontend/src/pages/resources.tsx
@@ -56,7 +56,7 @@ export const Resources = () => {
       actions={<ExportButton targets={targets} />}
     >
       <div className="flex flex-col gap-4">
-        <div className="flex flex-col md:flex-row gap-4 items-center justify-between">
+        <div className="flex flex-wrap gap-4 items-center justify-between">
           <div className="flex gap-4">
             {(is_admin || !disable_non_admin_create) && <Components.New />}
             <Components.GroupActions />

--- a/frontend/src/pages/resources.tsx
+++ b/frontend/src/pages/resources.tsx
@@ -56,7 +56,7 @@ export const Resources = () => {
       actions={<ExportButton targets={targets} />}
     >
       <div className="flex flex-col gap-4">
-        <div className="flex flex-col md:flex-row gap4 items-center justify-between">
+        <div className="flex flex-col md:flex-row gap-4 items-center justify-between">
           <div className="flex gap-4">
             {(is_admin || !disable_non_admin_create) && <Components.New />}
             <Components.GroupActions />

--- a/frontend/src/pages/resources.tsx
+++ b/frontend/src/pages/resources.tsx
@@ -56,7 +56,7 @@ export const Resources = () => {
       actions={<ExportButton targets={targets} />}
     >
       <div className="flex flex-col gap-4">
-        <div className="flex items-center justify-between">
+        <div className="flex flex-col md:flex-row gap4 items-center justify-between">
           <div className="flex gap-4">
             {(is_admin || !disable_non_admin_create) && <Components.New />}
             <Components.GroupActions />


### PR DESCRIPTION
Another small but annoying thing on mobile :) 

The quick actions above the table are not responsive, causing the whole page to be "wider" that the screen, not sure how to describe it but the page sort of floats all around:

<img width="490" alt="Screenshot 2025-02-13 at 14 56 15" src="https://github.com/user-attachments/assets/359e6f21-aa97-4930-a1df-031d0804ddf6" />


With this change, on small screens the actions are stacked, so the page is on the correct screen size: 

<img width="474" alt="Screenshot 2025-02-13 at 14 56 02" src="https://github.com/user-attachments/assets/da779fd1-42ca-4e09-8bb3-d6d7ef032360" />


With wide screens: 

<img width="1254" alt="Screenshot 2025-02-13 at 14 56 27" src="https://github.com/user-attachments/assets/fab76f94-9fc5-4ad1-9e07-4b9764481873" />
