### PR TITLE
docs: update demo credentials

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -4,7 +4,7 @@ A tool to build and deploy software across many servers.
 
 🦎 [See the docs](https://komo.do)
 
-🦎 [Try the Demo](https://demo.komo.do) - Login: `demo` : `demo`
+🦎 [Try the Demo](https://demo.komo.do) - Login: `komodo` : `komodo`
 
 🦎 [See the Build Server](https://build.komo.do)  - Login: `komodo` : `komodo`
 


### PR DESCRIPTION
Right now the readme has wrong credentials, a login with `demo`/`demo` doesn't work (see #310).

This PR changes the readme to working credentials.