### PR TITLE
Fix: amd64 architecture could trigger installation of aarch64 binary

### DIFF
--- a/scripts/setup-periphery.py
+++ b/scripts/setup-periphery.py
@@ -68,7 +68,7 @@ def copy_binary(user_install, bin_dir, version):
 
 	periphery_bin = "periphery-x86_64"
 	arch = platform.machine().lower()
-	if arch == "aarch64" or arch == "amd64":
+	if arch == "aarch64" or arch == "arm64":
 		print("aarch64 detected")
 		periphery_bin = "periphery-aarch64"
 	else:


### PR DESCRIPTION
'arm64' was mistyped as 'amd64', meaning if amd64 was the architecture, it would install the aarch64 binary rather than the x86_64 one. This PR fixes that.