### PR TITLE
Update config.tsx - Adding in better wording for Stack "run_directory" setting.

### DIFF
--- a/frontend/src/components/resources/stack/config.tsx
+++ b/frontend/src/components/resources/stack/config.tsx
@@ -561,7 +561,7 @@ export const StackConfig = ({
             run_directory: {
               label: "Run Directory",
               description:
-                "Set the working directory when running the compose up command, relative to the repo root.",
+                "Set the working directory when running the compose up command, relative to the stack root. ($periphery_stack_dir/$stack_name/$run_directory)",
               placeholder: "./path/to/folder",
             },
             file_paths: (value, set) => (


### PR DESCRIPTION
Changing the word repo to stack and then providing an example of where exactly the run_directory will run on the periphery + stack name will be used.