### PR TITLE
Fix: The {account} login fails when the name contains '$' sign

### DIFF
--- a/bin/periphery/src/docker.rs
+++ b/bin/periphery/src/docker.rs
@@ -945,7 +945,7 @@ pub async fn docker_login(
     None => crate::helpers::registry_token(domain, account)?,
   };
   let log = async_run_command(&format!(
-    "echo {registry_token} | docker login {domain} --username {account} --password-stdin",
+    "echo {registry_token} | docker login {domain} --username '{account}' --password-stdin",
   ))
   .await;
   if log.success() {


### PR DESCRIPTION
Just found a bug about the docker login process.
I tried Harbor as my image storage, their username always generate in the format of: `robot$something+username`.

I found that I could not set robot$something+username in the Registry Accounts Setting. 
It will lead to 
`Error response from daemon: Get "https://XXX/v2/": unauthorized`
After some research, docker login for this kind of username needs to be 
`docker login XXX --username 'robot$something+username'` instead of `docker login XXX --username robot$something+username`  stated in the code (username needs to be single quoted, found that the code are not quoted)

Not sure if normal username will be affected also
Tested in command line, single quoting a normal username on ghcr.io logins fine