### PR TITLE
Adding a read API endpoint to get container states similar to GetDeploymentsSummary but for all containers that Komodo can see.

### DIFF
--- a/bin/core/src/api/read/mod.rs
+++ b/bin/core/src/api/read/mod.rs
@@ -116,6 +116,7 @@ enum ReadRequest {
   InspectDockerImage(InspectDockerImage),
   ListDockerImageHistory(ListDockerImageHistory),
   InspectDockerVolume(InspectDockerVolume),
+  GetDockerContainersSummary(GetDockerContainersSummary),
   ListAllDockerContainers(ListAllDockerContainers),
   ListDockerContainers(ListDockerContainers),
   ListDockerNetworks(ListDockerNetworks),

--- a/bin/core/src/api/read/server.rs
+++ b/bin/core/src/api/read/server.rs
@@ -14,7 +14,9 @@ use komodo_client::{
     ResourceTarget,
     deployment::Deployment,
     docker::{
-      container::{Container, ContainerListItem},
+      container::{
+        Container, ContainerListItem, ContainerStateStatusEnum,
+      },
       image::{Image, ImageHistoryResponseItem},
       network::Network,
       volume::Volume,
@@ -410,6 +412,45 @@ impl Resolve<ReadArgs> for ListAllDockerContainers {
     }
 
     Ok(containers)
+  }
+}
+
+impl Resolve<ReadArgs> for GetDockerContainersSummary {
+  async fn resolve(
+    self,
+    ReadArgs { user }: &ReadArgs,
+  ) -> serror::Result<GetDockerContainersSummaryResponse> {
+    let servers = resource::list_full_for_user::<Server>(
+      Default::default(),
+      user,
+      &[],
+    )
+    .await
+    .context("failed to get containers from db")?;
+
+    let mut res = GetDockerContainersSummaryResponse::default();
+
+    for server in servers {
+      let cache = server_status_cache()
+        .get_or_insert_default(&server.id)
+        .await;
+
+      if let Some(containers) = &cache.containers {
+        for container in containers {
+          res.total += 1;
+          match container.state {
+            ContainerStateStatusEnum::Created
+            | ContainerStateStatusEnum::Paused
+            | ContainerStateStatusEnum::Exited => res.stopped += 1,
+            ContainerStateStatusEnum::Running => res.running += 1,
+            ContainerStateStatusEnum::Empty => res.unknown += 1,
+            _ => res.unhealthy += 1,
+          }
+        }
+      }
+    }
+
+    Ok(res)
   }
 }
 

--- a/bin/core/src/api/read/server.rs
+++ b/bin/core/src/api/read/server.rs
@@ -426,7 +426,7 @@ impl Resolve<ReadArgs> for GetDockerContainersSummary {
       &[],
     )
     .await
-    .context("failed to get containers from db")?;
+    .context("failed to get servers from db")?;
 
     let mut res = GetDockerContainersSummaryResponse::default();
 

--- a/client/core/rs/src/api/read/server.rs
+++ b/client/core/rs/src/api/read/server.rs
@@ -313,9 +313,9 @@ pub struct GetDockerContainersSummaryResponse {
   pub total: I64,
   /// The number of Containers with Running state
   pub running: I64,
-  /// The number of Containers with Stopped or Paused state
+  /// The number of Containers with Stopped or Paused or Created state
   pub stopped: I64,
-  /// The number of Containers with Restarting or Dead or Created (other) state
+  /// The number of Containers with Restarting or Dead state
   pub unhealthy: I64,
   /// The number of Containers with Unknown state
   pub unknown: I64,

--- a/client/core/rs/src/api/read/server.rs
+++ b/client/core/rs/src/api/read/server.rs
@@ -294,6 +294,35 @@ pub type ListAllDockerContainersResponse = Vec<ContainerListItem>;
 
 //
 
+/// Gets a summary of data relating to all containers.
+/// Response: [GetDockerContainersSummaryResponse].
+#[typeshare]
+#[derive(
+  Serialize, Deserialize, Debug, Clone, Resolve, EmptyTraits,
+)]
+#[empty_traits(KomodoReadRequest)]
+#[response(GetDockerContainersSummaryResponse)]
+#[error(serror::Error)]
+pub struct GetDockerContainersSummary {}
+
+/// Response for [GetDockerContainersSummary]
+#[typeshare]
+#[derive(Serialize, Deserialize, Debug, Clone, Default)]
+pub struct GetDockerContainersSummaryResponse {
+  /// The total number of Containers
+  pub total: I64,
+  /// The number of Containers with Running state
+  pub running: I64,
+  /// The number of Containers with Stopped or Paused state
+  pub stopped: I64,
+  /// The number of Containers with Restarting or Dead or Created (other) state
+  pub unhealthy: I64,
+  /// The number of Containers with Unknown state
+  pub unknown: I64,
+}
+
+//
+
 /// Inspect a docker container on the server. Response: [Container].
 #[typeshare]
 #[derive(

--- a/client/core/rs/src/api/read/server.rs
+++ b/client/core/rs/src/api/read/server.rs
@@ -310,15 +310,15 @@ pub struct GetDockerContainersSummary {}
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
 pub struct GetDockerContainersSummaryResponse {
   /// The total number of Containers
-  pub total: I64,
+  pub total: u32,
   /// The number of Containers with Running state
-  pub running: I64,
+  pub running: u32,
   /// The number of Containers with Stopped or Paused or Created state
-  pub stopped: I64,
+  pub stopped: u32,
   /// The number of Containers with Restarting or Dead state
-  pub unhealthy: I64,
+  pub unhealthy: u32,
   /// The number of Containers with Unknown state
-  pub unknown: I64,
+  pub unknown: u32,
 }
 
 //

--- a/client/core/ts/src/responses.ts
+++ b/client/core/ts/src/responses.ts
@@ -61,7 +61,7 @@ export type ReadResponses = {
   GetServer: Types.GetServerResponse;
   GetServerState: Types.GetServerStateResponse;
   GetPeripheryVersion: Types.GetPeripheryVersionResponse;
-  GetDockerContainersSummary: Types.GetDockerContainersSummary;
+  GetDockerContainersSummary: Types.GetDockerContainersSummaryResponse;
   ListDockerContainers: Types.ListDockerContainersResponse;
   ListAllDockerContainers: Types.ListAllDockerContainersResponse;
   InspectDockerContainer: Types.InspectDockerContainerResponse;

--- a/client/core/ts/src/responses.ts
+++ b/client/core/ts/src/responses.ts
@@ -61,6 +61,7 @@ export type ReadResponses = {
   GetServer: Types.GetServerResponse;
   GetServerState: Types.GetServerStateResponse;
   GetPeripheryVersion: Types.GetPeripheryVersionResponse;
+  GetDockerContainersSummary: Types.GetDockerContainersSummary;
   ListDockerContainers: Types.ListDockerContainersResponse;
   ListAllDockerContainers: Types.ListAllDockerContainersResponse;
   InspectDockerContainer: Types.InspectDockerContainerResponse;

--- a/client/core/ts/src/types.ts
+++ b/client/core/ts/src/types.ts
@@ -5170,6 +5170,27 @@ export interface GetDeploymentsSummaryResponse {
 }
 
 /**
+ * Gets a summary of data relating to all containers.
+ * Response: [GetDockerContainersSummaryResponse].
+ */
+export interface GetDockerContainersSummary {
+}
+
+/** Response for [GetDockerContainersSummary] */
+export interface GetDockerContainersSummaryResponse {
+	/** The total number of Containers */
+	total: I64;
+	/** The number of Containers with Running state */
+	running: I64;
+	/** The number of Containers with Stopped or Paused state */
+	stopped: I64;
+	/** The number of Containers with Restarting or Dead or Created (other) state */
+	unhealthy: I64;
+	/** The number of Containers with Unknown state */
+	unknown: I64;
+}
+
+/**
  * Get a specific docker registry account.
  * Response: [GetDockerRegistryAccountResponse].
  */
@@ -7648,6 +7669,7 @@ export type ReadRequest =
 	| { type: "InspectDockerImage", params: InspectDockerImage }
 	| { type: "ListDockerImageHistory", params: ListDockerImageHistory }
 	| { type: "InspectDockerVolume", params: InspectDockerVolume }
+	| { type: "GetDockerContainersSummary", params: GetDockerContainersSummary }
 	| { type: "ListAllDockerContainers", params: ListAllDockerContainers }
 	| { type: "ListDockerContainers", params: ListDockerContainers }
 	| { type: "ListDockerNetworks", params: ListDockerNetworks }

--- a/client/core/ts/src/types.ts
+++ b/client/core/ts/src/types.ts
@@ -5179,15 +5179,15 @@ export interface GetDockerContainersSummary {
 /** Response for [GetDockerContainersSummary] */
 export interface GetDockerContainersSummaryResponse {
 	/** The total number of Containers */
-	total: I64;
+	total: number;
 	/** The number of Containers with Running state */
-	running: I64;
+	running: number;
 	/** The number of Containers with Stopped or Paused or Created state */
-	stopped: I64;
+	stopped: number;
 	/** The number of Containers with Restarting or Dead state */
-	unhealthy: I64;
+	unhealthy: number;
 	/** The number of Containers with Unknown state */
-	unknown: I64;
+	unknown: number;
 }
 
 /**

--- a/client/core/ts/src/types.ts
+++ b/client/core/ts/src/types.ts
@@ -5182,9 +5182,9 @@ export interface GetDockerContainersSummaryResponse {
 	total: I64;
 	/** The number of Containers with Running state */
 	running: I64;
-	/** The number of Containers with Stopped or Paused state */
+	/** The number of Containers with Stopped or Paused or Created state */
 	stopped: I64;
-	/** The number of Containers with Restarting or Dead or Created (other) state */
+	/** The number of Containers with Restarting or Dead state */
 	unhealthy: I64;
 	/** The number of Containers with Unknown state */
 	unknown: I64;

--- a/frontend/public/client/responses.d.ts
+++ b/frontend/public/client/responses.d.ts
@@ -46,6 +46,7 @@ export type ReadResponses = {
     GetServer: Types.GetServerResponse;
     GetServerState: Types.GetServerStateResponse;
     GetPeripheryVersion: Types.GetPeripheryVersionResponse;
+    GetDockerContainersSummary: Types.GetDockerContainersSummary;
     ListDockerContainers: Types.ListDockerContainersResponse;
     ListAllDockerContainers: Types.ListAllDockerContainersResponse;
     InspectDockerContainer: Types.InspectDockerContainerResponse;

--- a/frontend/public/client/responses.d.ts
+++ b/frontend/public/client/responses.d.ts
@@ -46,7 +46,7 @@ export type ReadResponses = {
     GetServer: Types.GetServerResponse;
     GetServerState: Types.GetServerStateResponse;
     GetPeripheryVersion: Types.GetPeripheryVersionResponse;
-    GetDockerContainersSummary: Types.GetDockerContainersSummary;
+    GetDockerContainersSummary: Types.GetDockerContainersSummaryResponse;
     ListDockerContainers: Types.ListDockerContainersResponse;
     ListAllDockerContainers: Types.ListAllDockerContainersResponse;
     InspectDockerContainer: Types.InspectDockerContainerResponse;

--- a/frontend/public/client/types.d.ts
+++ b/frontend/public/client/types.d.ts
@@ -4937,9 +4937,9 @@ export interface GetDockerContainersSummaryResponse {
     total: I64;
     /** The number of Containers with Running state */
     running: I64;
-    /** The number of Containers with Stopped or Paused state */
+    /** The number of Containers with Stopped or Paused or Created state */
     stopped: I64;
-    /** The number of Containers with Restarting or Dead or Created (other) state */
+    /** The number of Containers with Restarting or Dead state */
     unhealthy: I64;
     /** The number of Containers with Unknown state */
     unknown: I64;

--- a/frontend/public/client/types.d.ts
+++ b/frontend/public/client/types.d.ts
@@ -4934,15 +4934,15 @@ export interface GetDockerContainersSummary {
 /** Response for [GetDockerContainersSummary] */
 export interface GetDockerContainersSummaryResponse {
     /** The total number of Containers */
-    total: I64;
+    total: number;
     /** The number of Containers with Running state */
-    running: I64;
+    running: number;
     /** The number of Containers with Stopped or Paused or Created state */
-    stopped: I64;
+    stopped: number;
     /** The number of Containers with Restarting or Dead state */
-    unhealthy: I64;
+    unhealthy: number;
     /** The number of Containers with Unknown state */
-    unknown: I64;
+    unknown: number;
 }
 /**
  * Get a specific docker registry account.

--- a/frontend/public/client/types.d.ts
+++ b/frontend/public/client/types.d.ts
@@ -4926,6 +4926,25 @@ export interface GetDeploymentsSummaryResponse {
     unknown: I64;
 }
 /**
+ * Gets a summary of data relating to all containers.
+ * Response: [GetDockerContainersSummaryResponse].
+ */
+export interface GetDockerContainersSummary {
+}
+/** Response for [GetDockerContainersSummary] */
+export interface GetDockerContainersSummaryResponse {
+    /** The total number of Containers */
+    total: I64;
+    /** The number of Containers with Running state */
+    running: I64;
+    /** The number of Containers with Stopped or Paused state */
+    stopped: I64;
+    /** The number of Containers with Restarting or Dead or Created (other) state */
+    unhealthy: I64;
+    /** The number of Containers with Unknown state */
+    unknown: I64;
+}
+/**
  * Get a specific docker registry account.
  * Response: [GetDockerRegistryAccountResponse].
  */
@@ -7401,6 +7420,9 @@ export type ReadRequest = {
 } | {
     type: "InspectDockerVolume";
     params: InspectDockerVolume;
+} | {
+    type: "GetDockerContainersSummary";
+    params: GetDockerContainersSummary;
 } | {
     type: "ListAllDockerContainers";
     params: ListAllDockerContainers;


### PR DESCRIPTION
I wanted to create a custom homepage widget for Komodo so I could just see what was running/stopped and a total count but an endpoint like `GetDeploymentsSummary` and `GetStacksSummary` didn't exist for all containers. 

At first, I just made a separate python API (https://github.com/alexshore/komodo-containers-api) but thought this could be a good way to up my contributions to open source software so heres my attempt at contributing a `GetDockerContainersSummary` endpoint :)

I'm not too fussed as what counts as what category. For my use-case it's helpful for there really to just be 2 final "states" that the docker containers are categorised into (i.e. just Stopped and Running) but thats a bit more specific to my use-case than to Komodo so right now they're split into Stopped, Running, Unknown and Unhealthy but that can be changed.

I also wasn't sure where in the file to put the new code so I just put it all next to `ListAllDockerContainers` as it performs a similar function.

Hope this is all good and doesn't need too many more changes! Thanks for your help in discord too :)