### PR TITLE
Improve docs around running periphery in a container

### DIFF
--- a/compose/periphery.compose.yaml
+++ b/compose/periphery.compose.yaml
@@ -37,3 +37,7 @@ services:
       ## or docker will get confused. See https://github.com/moghtech/komodo/discussions/180.
       ## Default: /etc/komodo.
       - ${PERIPHERY_ROOT_DIRECTORY:-/etc/komodo}:${PERIPHERY_ROOT_DIRECTORY:-/etc/komodo}
+    ## If periphery is being run remote from the core server, ports need
+    ## to be exposed on the host.
+    # ports:
+    #   - 8120:8120

--- a/compose/periphery.compose.yaml
+++ b/compose/periphery.compose.yaml
@@ -41,3 +41,5 @@ services:
     ## to be exposed on the host.
     # ports:
     #   - 8120:8120
+    ## If you want to use a custom periphery config file, use command to pass it to periphery.
+    # command: periphery --config-path ${PERIPHERY_ROOT_DIRECTORY:-/etc/komodo}/periphery.config.toml

--- a/docsite/docs/connect-servers.mdx
+++ b/docsite/docs/connect-servers.mdx
@@ -87,6 +87,11 @@ periphery \
 You can run `periphery --help` to see the manual.
 :::
 
+When running periphery in docker, use [command](https://docs.docker.com/reference/compose-file/services/#command) to pass in additional arguments.
+```
+command: periphery --config-path /path/in/container/to/periphery.config.base.toml
+```
+
 ### Passing config files
 
 Either file paths or directory paths can be passed to `--config-path`.

--- a/docsite/docs/connect-servers.mdx
+++ b/docsite/docs/connect-servers.mdx
@@ -77,7 +77,7 @@ Ensure that the user which periphery is run as has access to the docker group wi
 ```
 periphery \
 	--config-path /path/to/periphery.config.base.toml \
-	--config-path /other_path/to/overide-periphery-config-directory \
+	--config-path /other_path/to/override-periphery-config-directory \
 	--config-keyword periphery \
 	--config-keyword config \
 	--merge-nested-config true
@@ -93,15 +93,15 @@ Either file paths or directory paths can be passed to `--config-path`.
 
 When using directories, the file entries can be filtered by name with the `--config-keyword` argument, which can be passed multiple times to add more keywords. If passed, then only config files with file names that contain all keywords will be merged.
 
-When passing multiple config files, later --config-path given in the command will always overide previous ones. Directory config files are merged in alphabetical order by name, so `config_b.toml` will overide `config_a.toml`.
+When passing multiple config files, later --config-path given in the command will always override previous ones. Directory config files are merged in alphabetical order by name, so `config_b.toml` will override `config_a.toml`.
 
-There are two ways to merge config files. The default behavior is to completely replace any base fields with whatever fields are present in the overide config. So if you pass `allowed_ips = []` in your overide config, the final allowed_ips will be an empty list as well.
+There are two ways to merge config files. The default behavior is to completely replace any base fields with whatever fields are present in the override config. So if you pass `allowed_ips = []` in your override config, the final allowed_ips will be an empty list as well.
 
 `--merge-nested-config true` will merge config fields recursively and extend config array fields.
 
-For example, with `--merge-nested-config true` you can specify an allowed ip in the base config, and another in the overide config, they will both be present in the final config.
+For example, with `--merge-nested-config true` you can specify an allowed ip in the base config, and another in the override config, they will both be present in the final config.
 
-Similarly, you can specify a base docker / github account pair, and extend them with additional accounts in the overide config.
+Similarly, you can specify a base docker / github account pair, and extend them with additional accounts in the override config.
 
 ## Configuration
 


### PR DESCRIPTION
Hello, I want to start by thanking you for all the work you have put in to komodo. I just found it a couple weeks ago and have been migrating my systems to it. I have been using systemd to run periphery per the recommendations that you and FoxxMD have made, but I don't think that is practical for the last couple of systems, so I had to dig into running periphery in a container and ran into a couple things that weren't clear to me and required some guess and check, so I'm submitting this PR to hopefully eliminate that uncertainty for people in the future.

Happy to take any feedback and make changes as you see fit.