### PR TITLE
Make listener address configurable & Add support for IPv6

### DIFF
--- a/bin/core/src/config.rs
+++ b/bin/core/src/config.rs
@@ -139,7 +139,7 @@ pub fn core_config() -> &'static CoreConfig {
       title: env.komodo_title.unwrap_or(config.title),
       host: env.komodo_host.unwrap_or(config.host),
       port: env.komodo_port.unwrap_or(config.port),
-      listener_address: env.komodo_listener_address.unwrap_or(config.listener_address),
+      bind_ip: env.komodo_bind_ip.unwrap_or(config.bind_ip),
       first_server: env.komodo_first_server.unwrap_or(config.first_server),
       frontend_path: env.komodo_frontend_path.unwrap_or(config.frontend_path),
       jwt_ttl: env

--- a/bin/core/src/config.rs
+++ b/bin/core/src/config.rs
@@ -139,6 +139,7 @@ pub fn core_config() -> &'static CoreConfig {
       title: env.komodo_title.unwrap_or(config.title),
       host: env.komodo_host.unwrap_or(config.host),
       port: env.komodo_port.unwrap_or(config.port),
+      listener_address: env.komodo_listener_address.unwrap_or(config.listener_address),
       first_server: env.komodo_first_server.unwrap_or(config.first_server),
       frontend_path: env.komodo_frontend_path.unwrap_or(config.frontend_path),
       jwt_ttl: env

--- a/bin/core/src/main.rs
+++ b/bin/core/src/main.rs
@@ -86,9 +86,10 @@ async fn app() -> anyhow::Result<()> {
     )
     .into_make_service();
 
+  let addr = format!("{}:{}", core_config().listener_address, core_config().port);
   let socket_addr =
-    SocketAddr::from_str(&format!("0.0.0.0:{}", core_config().port))
-      .context("failed to parse socket addr")?;
+    SocketAddr::from_str(&addr)
+    .context("failed to parse listen address")?;
 
   if config.ssl_enabled {
     info!("🔒 Core SSL Enabled");

--- a/bin/core/src/main.rs
+++ b/bin/core/src/main.rs
@@ -86,7 +86,7 @@ async fn app() -> anyhow::Result<()> {
     )
     .into_make_service();
 
-  let addr = format!("{}:{}", core_config().listener_address, core_config().port);
+  let addr = format!("{}:{}", core_config().bind_ip, core_config().port);
   let socket_addr =
     SocketAddr::from_str(&addr)
     .context("failed to parse listen address")?;

--- a/bin/periphery/src/config.rs
+++ b/bin/periphery/src/config.rs
@@ -35,6 +35,7 @@ pub fn periphery_config() -> &'static PeripheryConfig {
 
     PeripheryConfig {
       port: env.periphery_port.unwrap_or(config.port),
+      listener_address: env.periphery_listener_address.unwrap_or(config.listener_address),
       repo_dir: env.periphery_repo_dir.unwrap_or(config.repo_dir),
       stack_dir: env.periphery_stack_dir.unwrap_or(config.stack_dir),
       stats_polling_rate: env

--- a/bin/periphery/src/config.rs
+++ b/bin/periphery/src/config.rs
@@ -35,7 +35,7 @@ pub fn periphery_config() -> &'static PeripheryConfig {
 
     PeripheryConfig {
       port: env.periphery_port.unwrap_or(config.port),
-      listener_address: env.periphery_listener_address.unwrap_or(config.listener_address),
+      bind_ip: env.periphery_bind_ip.unwrap_or(config.bind_ip),
       repo_dir: env.periphery_repo_dir.unwrap_or(config.repo_dir),
       stack_dir: env.periphery_stack_dir.unwrap_or(config.stack_dir),
       stats_polling_rate: env

--- a/bin/periphery/src/main.rs
+++ b/bin/periphery/src/main.rs
@@ -26,7 +26,7 @@ async fn app() -> anyhow::Result<()> {
 
   stats::spawn_system_stats_polling_thread();
 
-  let addr = format!("{}:{}", config::periphery_config().listener_address, config::periphery_config().port);
+  let addr = format!("{}:{}", config::periphery_config().bind_ip, config::periphery_config().port);
 
   let socket_addr = 
     SocketAddr::from_str(&addr)

--- a/bin/periphery/src/main.rs
+++ b/bin/periphery/src/main.rs
@@ -26,9 +26,11 @@ async fn app() -> anyhow::Result<()> {
 
   stats::spawn_system_stats_polling_thread();
 
-  let socket_addr =
-    SocketAddr::from_str(&format!("0.0.0.0:{}", config.port))
-      .context("failed to parse socket addr")?;
+  let addr = format!("{}:{}", config::periphery_config().listener_address, config::periphery_config().port);
+
+  let socket_addr = 
+    SocketAddr::from_str(&addr)
+    .context("failed to parse listen address")?;
 
   let app = router::router()
     .into_make_service_with_connect_info::<SocketAddr>();

--- a/client/core/rs/src/entities/config/core.rs
+++ b/client/core/rs/src/entities/config/core.rs
@@ -44,8 +44,8 @@ pub struct Env {
   pub komodo_host: Option<String>,
   /// Override `port`
   pub komodo_port: Option<u16>,
-  /// Override `listener_address`
-  pub komodo_listener_address: Option<String>,
+  /// Override `bind_ip`
+  pub komodo_bind_ip: Option<String>,
   /// Override `passkey`
   pub komodo_passkey: Option<String>,
   /// Override `passkey` with file
@@ -258,10 +258,10 @@ pub struct CoreConfig {
   #[serde(default = "default_core_port")]
   pub port: u16,
 
-  /// Address the core web server listens on.
+  /// IP address the core server binds to.
   /// Default: [::].
-   #[serde(default = "default_core_listener_address")]
-  pub listener_address: String,
+   #[serde(default = "default_core_bind_ip")]
+  pub bind_ip: String,
 
   /// Sent in auth header with req to periphery.
   /// Should be some secure hash, maybe 20-40 chars.
@@ -528,7 +528,7 @@ fn default_core_port() -> u16 {
   9120
 }
 
-fn default_core_listener_address() -> String {
+fn default_core_bind_ip() -> String {
   "[::]".to_string()
 }
 
@@ -582,7 +582,7 @@ impl CoreConfig {
       title: config.title,
       host: config.host,
       port: config.port,
-      listener_address: config.listener_address,
+      bind_ip: config.bind_ip,
       passkey: empty_or_redacted(&config.passkey),
       first_server: config.first_server,
       frontend_path: config.frontend_path,

--- a/client/core/rs/src/entities/config/core.rs
+++ b/client/core/rs/src/entities/config/core.rs
@@ -44,6 +44,8 @@ pub struct Env {
   pub komodo_host: Option<String>,
   /// Override `port`
   pub komodo_port: Option<u16>,
+  /// Override `listener_address`
+  pub komodo_listener_address: Option<String>,
   /// Override `passkey`
   pub komodo_passkey: Option<String>,
   /// Override `passkey` with file
@@ -255,6 +257,11 @@ pub struct CoreConfig {
   /// Default: 9120.
   #[serde(default = "default_core_port")]
   pub port: u16,
+
+  /// Address the core web server listens on.
+  /// Default: [::].
+   #[serde(default = "default_core_listener_address")]
+  pub listener_address: String,
 
   /// Sent in auth header with req to periphery.
   /// Should be some secure hash, maybe 20-40 chars.
@@ -521,6 +528,10 @@ fn default_core_port() -> u16 {
   9120
 }
 
+fn default_core_listener_address() -> String {
+  "[::]".to_string()
+}
+
 fn default_frontend_path() -> String {
   "/app/frontend".to_string()
 }
@@ -571,6 +582,7 @@ impl CoreConfig {
       title: config.title,
       host: config.host,
       port: config.port,
+      listener_address: config.listener_address,
       passkey: empty_or_redacted(&config.passkey),
       first_server: config.first_server,
       frontend_path: config.frontend_path,

--- a/client/core/rs/src/entities/config/periphery.rs
+++ b/client/core/rs/src/entities/config/periphery.rs
@@ -114,6 +114,8 @@ pub struct Env {
 
   /// Override `port`
   pub periphery_port: Option<u16>,
+  /// Override `listener_address`
+  pub periphery_listener_address: Option<String>,
   /// Override `repo_dir`
   pub periphery_repo_dir: Option<PathBuf>,
   /// Override `stack_dir`
@@ -161,6 +163,11 @@ pub struct PeripheryConfig {
   /// Default: `8120`
   #[serde(default = "default_periphery_port")]
   pub port: u16,
+
+  /// Address periphery listens on.
+  /// Default: [::].
+  #[serde(default = "default_periphery_listener_address")]
+  pub listener_address: String,
 
   /// The system directory where Komodo managed repos will be cloned.
   /// Default: `/etc/komodo/repos`
@@ -244,6 +251,10 @@ fn default_periphery_port() -> u16 {
   8120
 }
 
+fn default_periphery_listener_address() -> String {
+  "[::]".to_string()
+}
+
 fn default_repo_dir() -> PathBuf {
   "/etc/komodo/repos".parse().unwrap()
 }
@@ -272,6 +283,7 @@ impl Default for PeripheryConfig {
   fn default() -> Self {
     Self {
       port: default_periphery_port(),
+      listener_address: default_periphery_listener_address(),
       repo_dir: default_repo_dir(),
       stack_dir: default_stack_dir(),
       stats_polling_rate: default_stats_polling_rate(),
@@ -295,6 +307,7 @@ impl PeripheryConfig {
   pub fn sanitized(&self) -> PeripheryConfig {
     PeripheryConfig {
       port: self.port,
+      listener_address: self.listener_address.clone(),
       repo_dir: self.repo_dir.clone(),
       stack_dir: self.stack_dir.clone(),
       stats_polling_rate: self.stats_polling_rate,

--- a/client/core/rs/src/entities/config/periphery.rs
+++ b/client/core/rs/src/entities/config/periphery.rs
@@ -114,8 +114,8 @@ pub struct Env {
 
   /// Override `port`
   pub periphery_port: Option<u16>,
-  /// Override `listener_address`
-  pub periphery_listener_address: Option<String>,
+  /// Override `bind_ip`
+  pub periphery_bind_ip: Option<String>,
   /// Override `repo_dir`
   pub periphery_repo_dir: Option<PathBuf>,
   /// Override `stack_dir`
@@ -164,10 +164,10 @@ pub struct PeripheryConfig {
   #[serde(default = "default_periphery_port")]
   pub port: u16,
 
-  /// Address periphery listens on.
+  /// IP address the periphery server binds to.
   /// Default: [::].
-  #[serde(default = "default_periphery_listener_address")]
-  pub listener_address: String,
+  #[serde(default = "default_periphery_bind_ip")]
+  pub bind_ip: String,
 
   /// The system directory where Komodo managed repos will be cloned.
   /// Default: `/etc/komodo/repos`
@@ -251,7 +251,7 @@ fn default_periphery_port() -> u16 {
   8120
 }
 
-fn default_periphery_listener_address() -> String {
+fn default_periphery_bind_ip() -> String {
   "[::]".to_string()
 }
 
@@ -283,7 +283,7 @@ impl Default for PeripheryConfig {
   fn default() -> Self {
     Self {
       port: default_periphery_port(),
-      listener_address: default_periphery_listener_address(),
+      bind_ip: default_periphery_bind_ip(),
       repo_dir: default_repo_dir(),
       stack_dir: default_stack_dir(),
       stats_polling_rate: default_stats_polling_rate(),
@@ -307,7 +307,7 @@ impl PeripheryConfig {
   pub fn sanitized(&self) -> PeripheryConfig {
     PeripheryConfig {
       port: self.port,
-      listener_address: self.listener_address.clone(),
+      bind_ip: self.bind_ip.clone(),
       repo_dir: self.repo_dir.clone(),
       stack_dir: self.stack_dir.clone(),
       stats_polling_rate: self.stats_polling_rate,

--- a/config/core.config.toml
+++ b/config/core.config.toml
@@ -33,10 +33,11 @@ host = "https://demo.komo.do"
 ## Default: 9120
 port = 9120
 
-## The address the core system will listen on.
-## Env: KOMODO_LISTENER_ADDRESS
+## The IP address the core server will bind to.
+## The default will allow it to accept external IPv4 and IPv6 connections.
+## Env: KOMODO_BIND_IP
 ## Default: [::]
-listener_address = "[::]"
+bind_ip = "[::]"
 
 ## This is the token used to authenticate core requests to periphery.
 ## Ensure this matches a passkey in the connected periphery configs.

--- a/config/core.config.toml
+++ b/config/core.config.toml
@@ -33,6 +33,11 @@ host = "https://demo.komo.do"
 ## Default: 9120
 port = 9120
 
+## The address the core system will listen on.
+## Env: KOMODO_LISTENER_ADDRESS
+## Default: [::]
+listener_address = "[::]"
+
 ## This is the token used to authenticate core requests to periphery.
 ## Ensure this matches a passkey in the connected periphery configs.
 ## If the periphery servers don't have passkeys configured, this doesn't need to be changed.

--- a/config/periphery.config.toml
+++ b/config/periphery.config.toml
@@ -18,6 +18,11 @@
 ## Default: 8120
 port = 8120
 
+## The address the server will listen on.
+## Env: PERIPHERY_LISTENER_ADDRESS
+## Default: [::]
+listener_address = "[::]"
+
 ## The directory periphery will use to manage repos.
 ## The periphery user must have write access to this directory.
 ## Env: PERIPHERY_REPO_DIR

--- a/config/periphery.config.toml
+++ b/config/periphery.config.toml
@@ -18,10 +18,11 @@
 ## Default: 8120
 port = 8120
 
-## The address the server will listen on.
-## Env: PERIPHERY_LISTENER_ADDRESS
+## The IP address the periphery server will bind to.
+## The default will allow it to accept external IPv4 and IPv6 connections.
+## Env: PERIPHERY_BIND_IP
 ## Default: [::]
-listener_address = "[::]"
+bind_ip = "[::]"
 
 ## The directory periphery will use to manage repos.
 ## The periphery user must have write access to this directory.


### PR DESCRIPTION
This PR makes the listener address configurable for both Core and Periphery through the following env vars:

`CORE_LISTENER_ADDRESS`
`PERIPHERY_LISTENER_ADDRESS`

But the main purpose of this PR is to add support for IPv6.




Before:
```
ss -tulpn | grep 120
tcp   LISTEN 0      1024              0.0.0.0:9120       0.0.0.0:*    users:(("core",pid=4694,fd=13))          
tcp   LISTEN 0      1024              0.0.0.0:8120       0.0.0.0:*    users:(("periphery",pid=4702,fd=10))
```

After:
```
ss -tulpn | grep 120
tcp   LISTEN 0      1024                      *:8120             *:*    users:(("periphery",pid=163028,fd=9))    
tcp   LISTEN 0      1024                      *:9120             *:*    users:(("core",pid=163036,fd=15))
```


Fixes https://github.com/moghtech/komodo/issues/313