### PR TITLE
Ntfy alerter: Add support for email notifications, notification titles and message priorities

### DIFF
--- a/bin/core/src/alert/mod.rs
+++ b/bin/core/src/alert/mod.rs
@@ -130,8 +130,8 @@ pub async fn send_alert_to_alerter(
         )
       })
     }
-    AlerterEndpoint::Ntfy(NtfyAlerterEndpoint { url }) => {
-      ntfy::send_alert(url, alert).await.with_context(|| {
+    AlerterEndpoint::Ntfy(NtfyAlerterEndpoint { url, email }) => {
+      ntfy::send_alert(url, email.as_deref(), alert).await.with_context(|| {
         format!(
           "Failed to send alert to ntfy Alerter {}",
           alerter.name

--- a/bin/core/src/alert/ntfy.rs
+++ b/bin/core/src/alert/ntfy.rs
@@ -5,6 +5,7 @@ use super::*;
 #[instrument(level = "debug")]
 pub async fn send_alert(
   url: &str,
+  email: Option<&str>,
   alert: &Alert,
 ) -> anyhow::Result<()> {
   let level = fmt_level(alert.level);
@@ -224,19 +225,26 @@ pub async fn send_alert(
   };
 
   if !content.is_empty() {
-    send_message(url, content).await?;
+    send_message(url, email, content).await?;
   }
   Ok(())
 }
 
 async fn send_message(
   url: &str,
+  email: Option<&str>,
   content: String,
 ) -> anyhow::Result<()> {
-  let response = http_client()
-    .post(url)
-    .header("Title", "ntfy Alert")
-    .body(content)
+  let mut request = http_client()
+      .post(url)
+      .header("Title", "ntfy Alert")
+      .body(content);
+
+  if let Some(email) = email {
+    request = request.header("X-Email", email);
+  }
+
+  let response =request
     .send()
     .await
     .context("Failed to send message")?;

--- a/client/core/rs/src/entities/alerter.rs
+++ b/client/core/rs/src/entities/alerter.rs
@@ -211,12 +211,16 @@ pub struct NtfyAlerterEndpoint {
   #[serde(default = "default_ntfy_url")]
   #[builder(default = "default_ntfy_url()")]
   pub url: String,
+
+  // optional E-Mail Address to enable ntfy email notifications. SMTP must be configured on the ntfy server
+  pub email: Option<String>,
 }
 
 impl Default for NtfyAlerterEndpoint {
   fn default() -> Self {
     Self {
       url: default_ntfy_url(),
+      email: None,
     }
   }
 }

--- a/client/core/ts/src/types.ts
+++ b/client/core/ts/src/types.ts
@@ -6442,6 +6442,7 @@ export interface NameAndId {
 export interface NtfyAlerterEndpoint {
 	/** The ntfy topic URL */
 	url: string;
+	email?: string;
 }
 
 /** Pauses all containers on the target server. Response: [Update] */

--- a/frontend/public/client/types.d.ts
+++ b/frontend/public/client/types.d.ts
@@ -6096,6 +6096,7 @@ export interface NameAndId {
 export interface NtfyAlerterEndpoint {
     /** The ntfy topic URL */
     url: string;
+    email?: string;
 }
 /** Pauses all containers on the target server. Response: [Update] */
 export interface PauseAllContainers {

--- a/frontend/src/components/resources/alerter/config/endpoint.tsx
+++ b/frontend/src/components/resources/alerter/config/endpoint.tsx
@@ -8,6 +8,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@ui/select";
+import { Input } from "@ui/input";
 
 const ENDPOINT_TYPES: Types.AlerterEndpoint["type"][] = [
   "Custom",
@@ -58,6 +59,27 @@ export const EndpointConfig = ({
         }
         readOnly={disabled}
       />
+      {endpoint.type == "Ntfy" ? (
+        <ConfigItem
+          label="Email"
+          description="Request Ntfy to send an email to this address. SMTP must be configured on the Ntfy instance. Only one email address per alerter is supported."
+        >
+          <Input
+            value={endpoint.params.email}
+            type="email"
+            readOnly={disabled}
+            placeholder="john@example.com"
+            onChange={(input) =>
+              set({
+                ...endpoint,
+                params: { ...endpoint.params, email: input.target.value },
+              })
+            }
+          ></Input>
+        </ConfigItem>
+      ) : (
+        ""
+      )}
     </ConfigItem>
   );
 };
@@ -66,12 +88,12 @@ const default_url = (type: Types.AlerterEndpoint["type"]) => {
   return type === "Custom"
     ? "http://localhost:7000"
     : type === "Slack"
-    ? "https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX"
-    : type === "Discord"
-    ? "https://discord.com/api/webhooks/XXXXXXXXXXXX/XXXX-XXXXXXXXXX"
-    : type === "Ntfy"
-    ? "https://ntfy.sh/komodo"
-    : type === "Pushover"
-    ? "https://api.pushover.net/1/messages.json?token=XXXXXXXXXXXXX&user=XXXXXXXXXXXXX"
-    : "";
+      ? "https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX"
+      : type === "Discord"
+        ? "https://discord.com/api/webhooks/XXXXXXXXXXXX/XXXX-XXXXXXXXXX"
+        : type === "Ntfy"
+          ? "https://ntfy.sh/komodo"
+          : type === "Pushover"
+            ? "https://api.pushover.net/1/messages.json?token=XXXXXXXXXXXXX&user=XXXXXXXXXXXXX"
+            : "";
 };


### PR DESCRIPTION
Originally I only wanted a way to receive email notifications from komodo alerts, and found out that ntfy allows forwarding notifications via email by adding a "X-Email" header to a notification request. So I implemented that, and while I was at it, I also added support for customizing the notification title and message priority:

- in the frontend when setting the alerter type to "ntfy", new configuration fields will pop up
- the default notification title was change from "ntfy alert" to "Komodo Alert", and can be customized if desired
- the main use-case for message priorities is for usage with the ntfy android app, which will notify the user more (or less) urgently (see [the ntfy documentation](https://docs.ntfy.sh/publish/#message-priority))

For the future, maybe it would be nice to have email alert support directly as part of komodo, but that of course entails a bit more work than this:

- email support could maybe be handled with the [lettre](https://crates.io/crates/lettre) crate? 
- smtp server configuration must be handled (as a resource, or just via `core.config.toml`?)
- multiple email recepients could be supported (ntfy only supports one "X-Email" header, so for each email receipient a separate alerter must be configured, which should also be publishing to a different topic. Its all a bit inconvienient)