### PR TITLE
Allow CIDR ranges in Allowed IPs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -129,3 +129,4 @@ colored = "3.0.0"
 regex = "1.11.1"
 bytes = "1.10.1"
 bson = "2.15.0"
+ipnetwork = { version = "0.21.1", features = ["serde"] }

--- a/bin/periphery/Cargo.toml
+++ b/bin/periphery/Cargo.toml
@@ -57,3 +57,4 @@ clap.workspace = true
 envy.workspace = true
 uuid.workspace = true
 rand.workspace = true
+ipnetwork.workspace = true

--- a/client/core/rs/Cargo.toml
+++ b/client/core/rs/Cargo.toml
@@ -44,3 +44,4 @@ envy.workspace = true
 uuid.workspace = true
 clap.workspace = true
 bson.workspace = true
+ipnetwork.workspace = true

--- a/client/core/rs/src/entities/config/periphery.rs
+++ b/client/core/rs/src/entities/config/periphery.rs
@@ -12,8 +12,8 @@
 //! the configuration file.
 //!
 
-use std::{collections::HashMap, net::IpAddr, path::PathBuf};
-
+use std::{collections::HashMap, path::PathBuf};
+use ipnetwork::IpNetwork;
 use clap::Parser;
 use serde::Deserialize;
 
@@ -150,7 +150,7 @@ pub struct Env {
   pub periphery_pretty_startup_config: Option<bool>,
 
   /// Override `allowed_ips`
-  pub periphery_allowed_ips: Option<Vec<IpAddr>>,
+  pub periphery_allowed_ips: Option<Vec<IpNetwork>>,
   /// Override `passkeys`
   pub periphery_passkeys: Option<Vec<String>>,
   /// Override `passkeys` from file
@@ -250,12 +250,12 @@ pub struct PeripheryConfig {
   #[serde(default)]
   pub pretty_startup_config: bool,
 
-  /// Limits which IPv4 addresses are allowed to call the api.
+  /// Limits which IP addresses are allowed to call the api.
   /// Default: none
   ///
   /// Note: this should be configured to increase security.
   #[serde(default)]
-  pub allowed_ips: Vec<IpAddr>,
+  pub allowed_ips: Vec<IpNetwork>,
 
   /// Limits the accepted passkeys.
   /// Default: none


### PR DESCRIPTION
Attempt to implement #631 

Changes `allowed_ips` from `IpAddr` to `IpNetwork`. The default serde will accept IP addresses and convert them to a /32 or /128 prefix if needed (depending on if the IP is v4 or v6).

For example
```yaml
  periphery:
    environment:
      PERIPHERY_ALLOWED_IPS: "172.25.3.0/24,172.25.0.4,::ffff:172.25.55.3/64,::ffff:172.25.55.4"
```
Turns into
```
allowed_ips: [V4(Ipv4Network { addr: 172.25.3.0, prefix: 24 }), V4(Ipv4Network { addr: 172.25.0.4, prefix: 32 }), V6(Ipv6Network { addr: ::ffff:172.25.55.3, prefix: 64 }), V6(Ipv6Network { addr: ::ffff:172.25.55.4, prefix: 128 })]
```

I also added a check to the matching function in `guard_request_by_ip` that will check the ip network type, and when the network is IPv4, it will convert the address to its canonical form. This way, you can use a standard IPv4 address without IPv6 mapping, even if your bind IP is `[::]`

Will test some more tonight with more corner cases, but working for me with basic tests.
