### PR TITLE
Fix Google Login enabled message

### DIFF
--- a/bin/core/src/api/auth.rs
+++ b/bin/core/src/api/auth.rs
@@ -62,7 +62,7 @@ pub fn router() -> Router {
   }
 
   if google_oauth_client().is_some() {
-    info!("🔑 Github Login Enabled");
+    info!("🔑 Google Login Enabled");
     router = router.nest("/google", google::router())
   }
 


### PR DESCRIPTION
- it was showing "Github Login" instead of "Google Login"