### PR TITLE
add user agent to oidc requests

### DIFF
--- a/bin/core/src/auth/oidc/mod.rs
+++ b/bin/core/src/auth/oidc/mod.rs
@@ -31,11 +31,17 @@ use super::RedirectQuery;
 
 pub mod client;
 
+static APP_USER_AGENT: &str = concat!(
+    "Komodo/",
+    env!("CARGO_PKG_VERSION"),
+);
+
 fn reqwest_client() -> &'static reqwest::Client {
   static REQWEST: OnceLock<reqwest::Client> = OnceLock::new();
   REQWEST.get_or_init(|| {
     reqwest::Client::builder()
       .redirect(reqwest::redirect::Policy::none())
+			.user_agent(APP_USER_AGENT)
       .build()
       .expect("Invalid OIDC reqwest client")
   })


### PR DESCRIPTION
Komodo is making a request to the oidc discoverable endpoint every 60s.

currently the user agent is empty, making investigations into request utilization difficult. 

this adds a Komodo specific user agent to allow others to easily discover when Komodo is making requests to their other services.

fixes: #660 