### PR TITLE
Add manual network interface configuration for multi-NIC Docker environments

### DIFF
--- a/bin/core/debian-deps.sh
+++ b/bin/core/debian-deps.sh
@@ -3,7 +3,7 @@
 ## Core deps installer
 
 apt-get update
-apt-get install -y git curl ca-certificates
+apt-get install -y git curl ca-certificates iproute2
 
 rm -rf /var/lib/apt/lists/*
 

--- a/bin/core/src/config.rs
+++ b/bin/core/src/config.rs
@@ -205,6 +205,7 @@ pub fn core_config() -> &'static CoreConfig {
           .unwrap_or(config.logging.opentelemetry_service_name),
       },
       pretty_startup_config: env.komodo_pretty_startup_config.unwrap_or(config.pretty_startup_config),
+      internet_interface: env.komodo_internet_interface.or(config.internet_interface),
       ssl_enabled: env.komodo_ssl_enabled.unwrap_or(config.ssl_enabled),
       ssl_key_file: env.komodo_ssl_key_file.unwrap_or(config.ssl_key_file),
       ssl_cert_file: env.komodo_ssl_cert_file.unwrap_or(config.ssl_cert_file),

--- a/bin/core/src/config.rs
+++ b/bin/core/src/config.rs
@@ -205,7 +205,7 @@ pub fn core_config() -> &'static CoreConfig {
           .unwrap_or(config.logging.opentelemetry_service_name),
       },
       pretty_startup_config: env.komodo_pretty_startup_config.unwrap_or(config.pretty_startup_config),
-      internet_interface: env.komodo_internet_interface.or(config.internet_interface),
+      internet_interface: env.komodo_internet_interface.unwrap_or(config.internet_interface),
       ssl_enabled: env.komodo_ssl_enabled.unwrap_or(config.ssl_enabled),
       ssl_key_file: env.komodo_ssl_key_file.unwrap_or(config.ssl_key_file),
       ssl_cert_file: env.komodo_ssl_cert_file.unwrap_or(config.ssl_cert_file),

--- a/bin/core/src/main.rs
+++ b/bin/core/src/main.rs
@@ -21,6 +21,7 @@ mod config;
 mod helpers;
 mod listener;
 mod monitor;
+mod network;
 mod permission;
 mod resource;
 mod schedule;

--- a/bin/core/src/network/mod.rs
+++ b/bin/core/src/network/mod.rs
@@ -1,0 +1,228 @@
+use anyhow::{Context, anyhow};
+use tokio::process::Command;
+use tracing::{info, warn, debug};
+
+/// Multi-NIC Internet Gateway Configuration
+/// 
+/// This module provides functionality to manually configure the internet gateway
+/// when running in multi-network Docker environments. Useful when Docker's default
+/// gateway selection doesn't choose the correct internet-connected interface.
+
+/// Check if we're running in a container environment
+fn is_container_environment() -> bool {
+    std::path::Path::new("/.dockerenv").exists() ||
+    std::env::var("container").is_ok() ||
+    std::fs::read_to_string("/proc/1/cgroup")
+        .map(|content| content.contains("docker") || content.contains("containerd"))
+        .unwrap_or(false)
+}
+
+/// Main function to configure internet gateway
+/// This should be called early in the application startup
+pub async fn configure_internet_gateway(internet_interface: Option<String>) -> anyhow::Result<()> {
+    if !is_container_environment() {
+        debug!("[KOMODO-NETWORK] Not running in container, skipping gateway configuration");
+        return Ok(());
+    }
+
+    // Check if manual interface configuration is provided
+    if let Some(interface_name) = internet_interface {
+        info!("[KOMODO-NETWORK] Configuring manual internet interface: {}", interface_name);
+        return configure_manual_internet_interface(&interface_name).await;
+    }
+
+    debug!("[KOMODO-NETWORK] No manual interface configuration provided, using default system routing");
+    Ok(())
+}
+
+/// Configure a manually specified internet interface
+async fn configure_manual_internet_interface(interface_name: &str) -> anyhow::Result<()> {
+    info!("[KOMODO-NETWORK] Setting up internet gateway for interface: {}", interface_name);
+    
+    // First, verify the interface exists and is up
+    let interface_check = Command::new("ip")
+        .args(&["addr", "show", interface_name])
+        .output()
+        .await
+        .context("Failed to check interface status")?;
+    
+    if !interface_check.status.success() {
+        return Err(anyhow!("Interface {} does not exist or is not accessible", interface_name));
+    }
+    
+    let interface_info = String::from_utf8_lossy(&interface_check.stdout);
+    if !interface_info.contains("state UP") {
+        return Err(anyhow!("Interface {} is not in UP state", interface_name));
+    }
+    
+    debug!("[KOMODO-NETWORK] Interface {} is available and UP", interface_name);
+    
+    // Find the gateway for this interface
+    let gateway = find_gateway_for_interface(interface_name).await?;
+    info!("[KOMODO-NETWORK] Found gateway {} for interface {}", gateway, interface_name);
+    
+    // Configure this interface as the primary internet gateway
+    set_default_gateway(&gateway, interface_name).await?;
+    
+    info!("[KOMODO-NETWORK] ✅ Successfully configured {} as primary internet interface", interface_name);
+    Ok(())
+}
+
+/// Find gateway for a specific interface
+async fn find_gateway_for_interface(interface_name: &str) -> anyhow::Result<String> {
+    // Get the IP address and network for this interface
+    let addr_output = Command::new("ip")
+        .args(&["addr", "show", interface_name])
+        .output()
+        .await
+        .context("Failed to get interface address")?;
+    
+    let addr_info = String::from_utf8_lossy(&addr_output.stdout);
+    
+    // Extract IP/CIDR from interface info
+    for line in addr_info.lines() {
+        if line.trim().starts_with("inet ") && !line.contains("127.0.0.1") {
+            let parts: Vec<&str> = line.trim().split_whitespace().collect();
+            if let Some(ip_cidr) = parts.get(1) {
+                debug!("[KOMODO-NETWORK] Interface {} has IP {}", interface_name, ip_cidr);
+                return find_gateway_for_interface_network(interface_name, ip_cidr).await;
+            }
+        }
+    }
+    
+    Err(anyhow!("Could not find IP address for interface {}", interface_name))
+}
+
+/// Find the gateway for an interface by analyzing its network
+async fn find_gateway_for_interface_network(interface_name: &str, ip_cidr: &str) -> anyhow::Result<String> {
+    debug!("[KOMODO-NETWORK] Finding gateway for interface {} in network {}", interface_name, ip_cidr);
+    
+    // First, try to find gateway from routing table for this specific network
+    let route_output = Command::new("ip")
+        .args(&["route", "show", "dev", interface_name])
+        .output()
+        .await
+        .context("Failed to get routes for interface")?;
+
+    if route_output.status.success() {
+        let routes = String::from_utf8(route_output.stdout)?;
+        debug!("[KOMODO-NETWORK] Routes for {}: {}", interface_name, routes);
+
+        // Look for any route with a gateway on this interface
+        for line in routes.lines() {
+            if line.contains("via") {
+                let parts: Vec<&str> = line.split_whitespace().collect();
+                if let Some(via_idx) = parts.iter().position(|&x| x == "via") {
+                    if let Some(&gateway) = parts.get(via_idx + 1) {
+                        debug!("[KOMODO-NETWORK] Found gateway {} for interface {} from routing table", gateway, interface_name);
+                        return Ok(gateway.to_string());
+                    }
+                }
+            }
+        }
+    }
+
+    // If no explicit gateway found, derive it from network configuration
+    // In Docker networks, the gateway is typically the .1 address of the subnet
+    if let Some(network_base) = ip_cidr.split('/').next() {
+        let ip_parts: Vec<&str> = network_base.split('.').collect();
+        if ip_parts.len() == 4 {
+            // For Docker networks, try .1 first (most common), then .254
+            let potential_gateways = vec![
+                format!("{}.{}.{}.1", ip_parts[0], ip_parts[1], ip_parts[2]),
+                format!("{}.{}.{}.254", ip_parts[0], ip_parts[1], ip_parts[2]),
+            ];
+
+            for gateway in potential_gateways {
+                debug!("[KOMODO-NETWORK] Testing potential gateway {} for interface {}", gateway, interface_name);
+                
+                // Check if we can add a route via this gateway
+                let route_test = Command::new("ip")
+                    .args(&["route", "get", &gateway, "dev", interface_name])
+                    .output()
+                    .await;
+
+                if let Ok(output) = route_test {
+                    if output.status.success() {
+                        debug!("[KOMODO-NETWORK] Gateway {} is reachable via interface {}", gateway, interface_name);
+                        return Ok(gateway.to_string());
+                    }
+                }
+                
+                // Fallback: If route test fails, just assume .1 is the gateway for Docker networks
+                if gateway.ends_with(".1") {
+                    debug!("[KOMODO-NETWORK] Assuming Docker gateway {} for interface {} (standard .1 convention)", gateway, interface_name);
+                    return Ok(gateway.to_string());
+                }
+            }
+        }
+    }
+
+    Err(anyhow!("Could not determine gateway for interface {}", interface_name))
+}
+
+/// Set the default gateway to use a specific interface and gateway
+async fn set_default_gateway(gateway: &str, interface_name: &str) -> anyhow::Result<()> {
+    info!("[KOMODO-NETWORK] Setting default gateway to {} via {}", gateway, interface_name);
+    
+    // Check if we have network privileges
+    if !check_network_privileges().await {
+        warn!("[KOMODO-NETWORK] Container lacks network privileges (NET_ADMIN capability required)");
+        warn!("[KOMODO-NETWORK] Add 'cap_add: [NET_ADMIN]' to docker-compose.yaml");
+        return Err(anyhow!("Insufficient network privileges to modify routing table"));
+    }
+    
+    // Remove existing default routes
+    debug!("[KOMODO-NETWORK] Removing existing default routes");
+    let remove_default = Command::new("sh")
+        .args(&["-c", "ip route del default 2>/dev/null || true"])
+        .output()
+        .await;
+    
+    if let Ok(output) = remove_default {
+        if output.status.success() {
+            debug!("[KOMODO-NETWORK] Removed existing default routes");
+        }
+    }
+    
+    // Add new default route via specified gateway and interface
+    let add_default_cmd = format!("ip route add default via {} dev {}", gateway, interface_name);
+    debug!("[KOMODO-NETWORK] Adding default route: {}", add_default_cmd);
+    
+    let add_default = Command::new("sh")
+        .args(&["-c", &add_default_cmd])
+        .output()
+        .await
+        .context("Failed to add default route")?;
+    
+    if !add_default.status.success() {
+        let error = String::from_utf8_lossy(&add_default.stderr);
+        return Err(anyhow!("Failed to set default gateway: {}", error));
+    }
+    
+    info!("[KOMODO-NETWORK] ✅ Default gateway successfully set to {} via {}", gateway, interface_name);
+    
+    // Verify the new routing
+    let verify_route = Command::new("ip")
+        .args(&["route", "show", "default"])
+        .output()
+        .await?;
+    
+    let route_info = String::from_utf8_lossy(&verify_route.stdout);
+    debug!("[KOMODO-NETWORK] Current default routes:\n{}", route_info);
+    
+    Ok(())
+}
+
+/// Check if we have sufficient network privileges
+async fn check_network_privileges() -> bool {
+    let output = Command::new("ip")
+        .args(&["route", "show"])
+        .output()
+        .await;
+    
+    match output {
+        Ok(out) => out.status.success(),
+        Err(_) => false,
+    }
+}

--- a/bin/core/src/startup.rs
+++ b/bin/core/src/startup.rs
@@ -27,6 +27,7 @@ use crate::{
   config::core_config,
   helpers::random_string,
   helpers::update::init_execution_update,
+  network,
   resource,
   state::db_client,
 };
@@ -34,6 +35,16 @@ use crate::{
 /// This function should be run on startup,
 /// after the db client has been initialized
 pub async fn on_startup() {
+  // Configure manual network interface if specified
+  let config = core_config();
+  if config.internet_interface.is_some() {
+    if let Err(e) = network::configure_internet_gateway(
+      config.internet_interface.clone()
+    ).await {
+      tracing::warn!("Failed to configure internet gateway: {:#}", e);
+    }
+  }
+
   tokio::join!(
     in_progress_update_cleanup(),
     open_alert_cleanup(),

--- a/bin/core/src/startup.rs
+++ b/bin/core/src/startup.rs
@@ -37,11 +37,11 @@ use crate::{
 pub async fn on_startup() {
   // Configure manual network interface if specified
   let config = core_config();
-  if config.internet_interface.is_some() {
+  if !config.internet_interface.is_empty() {
     if let Err(e) = network::configure_internet_gateway(
       config.internet_interface.clone()
     ).await {
-      tracing::warn!("Failed to configure internet gateway: {:#}", e);
+      tracing::warn!("Failed to configure internet gateway: {e:#?}");
     }
   }
 

--- a/client/core/rs/src/entities/config/core.rs
+++ b/client/core/rs/src/entities/config/core.rs
@@ -219,6 +219,9 @@ pub struct Env {
   /// Override `aws.secret_access_key` with file
   pub komodo_aws_secret_access_key_file: Option<PathBuf>,
 
+  /// Override `internet_interface` - manually specify which network interface to use for internet connectivity
+  pub komodo_internet_interface: Option<String>,
+
   /// Override `ssl_enabled`.
   pub komodo_ssl_enabled: Option<bool>,
   /// Override `ssl_key_file`
@@ -536,6 +539,16 @@ pub struct CoreConfig {
   /// Default: `/action-cache`
   #[serde(default = "default_action_directory")]
   pub action_directory: PathBuf,
+
+
+  /// Manually specify which network interface to use for internet connectivity.
+  /// When specified, Komodo will configure routing to use this interface as default route.
+  /// Useful in Docker environments with multiple networks where Docker's default gateway 
+  /// selection may not choose the internet-connected interface.
+  /// Example: "eth1", "ens18", "enp0s8"
+  /// Default: None (use default system routing)
+  #[serde(default)]
+  pub internet_interface: Option<String>,
 }
 
 fn default_title() -> String {
@@ -610,6 +623,7 @@ impl CoreConfig {
       repo_directory: config.repo_directory,
       action_directory: config.action_directory,
       sync_directory: config.sync_directory,
+      internet_interface: config.internet_interface,
       resource_poll_interval: config.resource_poll_interval,
       monitoring_interval: config.monitoring_interval,
       keep_stats_for_days: config.keep_stats_for_days,

--- a/client/core/rs/src/entities/config/core.rs
+++ b/client/core/rs/src/entities/config/core.rs
@@ -219,7 +219,7 @@ pub struct Env {
   /// Override `aws.secret_access_key` with file
   pub komodo_aws_secret_access_key_file: Option<PathBuf>,
 
-  /// Override `internet_interface` - manually specify which network interface to use for internet connectivity
+  /// Override `internet_interface`
   pub komodo_internet_interface: Option<String>,
 
   /// Override `ssl_enabled`.
@@ -268,6 +268,10 @@ pub struct CoreConfig {
   /// Default: [::].
   #[serde(default = "default_core_bind_ip")]
   pub bind_ip: String,
+
+  /// Interface to use as default route in multi-NIC environments.
+  #[serde(default = "default_internet_interface")]
+  pub internet_interface: String,
 
   /// Sent in auth header with req to periphery.
   /// Should be some secure hash, maybe 20-40 chars.
@@ -539,20 +543,14 @@ pub struct CoreConfig {
   /// Default: `/action-cache`
   #[serde(default = "default_action_directory")]
   pub action_directory: PathBuf,
-
-
-  /// Manually specify which network interface to use for internet connectivity.
-  /// When specified, Komodo will configure routing to use this interface as default route.
-  /// Useful in Docker environments with multiple networks where Docker's default gateway 
-  /// selection may not choose the internet-connected interface.
-  /// Example: "eth1", "ens18", "enp0s8"
-  /// Default: None (use default system routing)
-  #[serde(default)]
-  pub internet_interface: Option<String>,
 }
 
 fn default_title() -> String {
   String::from("Komodo")
+}
+
+fn default_internet_interface() -> String {
+  String::new()
 }
 
 fn default_core_port() -> u16 {

--- a/config/core.config.toml
+++ b/config/core.config.toml
@@ -39,13 +39,6 @@ port = 9120
 ## Default: [::]
 bind_ip = "[::]"
 
-## Manually specify which network interface to use for internet access.
-## Useful in multi-NIC Docker environments where the default gateway selection
-## doesn't choose the correct internet-connected interface.
-## Env: KOMODO_INTERNET_INTERFACE
-## Optional, no default. Example: "eth1"
-# internet_interface = "eth1"
-
 ## This is the token used to authenticate core requests to periphery.
 ## Ensure this matches a passkey in the connected periphery configs.
 ## If the periphery servers don't have passkeys configured, this doesn't need to be changed.
@@ -95,6 +88,11 @@ repo_directory = "/repo-cache"
 ## Env: KOMODO_ACTION_DIRECTORY
 ## Default: /action-cache
 action_directory = "/action-cache"
+
+## Interface to use as default route in multi-NIC environments.
+## Env: KOMODO_INTERNET_INTERFACE
+## Optional, no default.
+# internet_interface = "eth1"
 
 ################
 # AUTH / LOGIN #

--- a/config/core.config.toml
+++ b/config/core.config.toml
@@ -39,6 +39,13 @@ port = 9120
 ## Default: [::]
 bind_ip = "[::]"
 
+## Manually specify which network interface to use for internet access.
+## Useful in multi-NIC Docker environments where the default gateway selection
+## doesn't choose the correct internet-connected interface.
+## Env: KOMODO_INTERNET_INTERFACE
+## Optional, no default. Example: "eth1"
+# internet_interface = "eth1"
+
 ## This is the token used to authenticate core requests to periphery.
 ## Ensure this matches a passkey in the connected periphery configs.
 ## If the periphery servers don't have passkeys configured, this doesn't need to be changed.


### PR DESCRIPTION
# Problem
In Docker setups with multiple network interfaces, users cannot specify which interface should handle internet traffic, leading to unpredictable routing behavior. This causes problems when working with external hosted repositories. While Docker Compose version `2.32+` provides network interface priority `gw_priority` settings (which I recommend using bevor), some edge case scenarios require the ability to manually set the container interface for the default gateway.

# Solution
Added `internet_interface` configuration allows manual specification of which network interface of the container should be used as the default gateway. The feature automatically detects Docker environments and configures the routing table to route internet traffic through the specified interface.

## How it works:

1. Validates the specified interface exists and is UP
2. Discovers the gateway for the interface's network
3. Sets the interface as the default route for internet traffic
4. Provides clear error messages if privileges or configuration are missing

# Usage
```
# config/core.config.toml
internet_interface = "eth1"
```

```
# docker-compose.yaml
services:
  core:
    cap_add: [NET_ADMIN]
    environment:
      KOMODO_INTERNET_INTERFACE: "eth1"
```

# Changes
- New: mod.rs - Network configuration module
- Modified: Core config to support internet_interface field
- Modified: Startup integration for network setup

# Requirements
- `NET_ADMIN` capability for Docker containers
- iproute2 (injected by debian-deps.sh)