### PR TITLE
feat(dashboard): display CPU, memory, and disk usage on server cards

### DIFF
--- a/frontend/src/components/resources/server/index.tsx
+++ b/frontend/src/components/resources/server/index.tsx
@@ -33,6 +33,7 @@ import { StackTable } from "../stack/table";
 import { ResourceComponents } from "..";
 import { ServerInfo } from "./info";
 import { ServerStats } from "./stats";
+import { ServerStatsMini } from "./stats-mini";
 import { GroupActions } from "@components/group-actions";
 import { ServerTerminals } from "@components/terminal/server";
 import { usePermissions } from "@lib/hooks";
@@ -252,6 +253,8 @@ export const ServerVersion = ({ id }: { id: string }) => {
     </Tooltip>
   );
 };
+
+export { ServerStatsMini };
 
 export const ServerComponents: RequiredResourceComponents = {
   list_item: (id) => useServer(id),

--- a/frontend/src/components/resources/server/stats-mini.tsx
+++ b/frontend/src/components/resources/server/stats-mini.tsx
@@ -1,0 +1,106 @@
+import { useRead } from "@lib/hooks";
+import { cn } from "@lib/utils";
+import { Progress } from "@ui/progress";
+import { Cpu, Database, MemoryStick } from "lucide-react";
+
+interface ServerStatsMiniProps {
+  id: string;
+  className?: string;
+}
+
+export const ServerStatsMini = ({ id, className }: ServerStatsMiniProps) => {
+  const calculatePercentage = (value: number) =>
+    Number((value || 0).toFixed(2));
+  const getTextColor = (percentage: number) => {
+    if (percentage >= 90) return "text-red-600";
+    if (percentage >= 75) return "text-yellow-600";
+    return "text-green-600";
+  };
+
+  const server = useRead("ListServers", {}).data?.find((s) => s.id === id);
+  const stats = useRead(
+    "GetSystemStats",
+    { server: id },
+    {
+      enabled: server ? server.info.state !== "Disabled" : false,
+      refetchInterval: 10_000,
+    },
+  ).data;
+
+  if (!server || server.info.state === "Disabled" || !stats) {
+    return null;
+  }
+
+  const cpuPercentage = calculatePercentage(stats.cpu_perc);
+  const memoryPercentage = calculatePercentage(
+    (stats.mem_used_gb / stats.mem_total_gb) * 100,
+  );
+
+  const diskUsed = stats.disks.reduce((acc, disk) => acc + disk.used_gb, 0);
+  const diskTotal = stats.disks.reduce((acc, disk) => acc + disk.total_gb, 0);
+  const diskPercentage = calculatePercentage((diskUsed / diskTotal) * 100);
+
+  return (
+    <div className={cn("flex flex-col gap-2", className)}>
+      <div className="flex items-center gap-2">
+        <Cpu className="w-3 h-3 text-muted-foreground" />
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center justify-between mb-1">
+            <span className="text-xs text-muted-foreground">CPU</span>
+            <span
+              className={cn("text-xs font-medium", getTextColor(cpuPercentage))}
+            >
+              {cpuPercentage}%
+            </span>
+          </div>
+          <Progress
+            value={cpuPercentage}
+            className={cn("h-1", "[&>div]:transition-all")}
+          />
+        </div>
+      </div>
+
+      <div className="flex items-center gap-2">
+        <MemoryStick className="w-3 h-3 text-muted-foreground" />
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center justify-between mb-1">
+            <span className="text-xs text-muted-foreground">Memory</span>
+            <span
+              className={cn(
+                "text-xs font-medium",
+                getTextColor(memoryPercentage),
+              )}
+            >
+              {memoryPercentage}%
+            </span>
+          </div>
+          <Progress
+            value={memoryPercentage}
+            className={cn("h-1", "[&>div]:transition-all")}
+          />
+        </div>
+      </div>
+
+      <div className="flex items-center gap-2">
+        <Database className="w-3 h-3 text-muted-foreground" />
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center justify-between mb-1">
+            <span className="text-xs text-muted-foreground">Disk</span>
+            <span
+              className={cn(
+                "text-xs font-medium",
+                getTextColor(diskPercentage),
+              )}
+            >
+              {diskPercentage}%
+            </span>
+          </div>
+          <Progress
+            value={diskPercentage}
+            className={cn("h-1", "[&>div]:transition-all")}
+          />
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/components/resources/server/stats-mini.tsx
+++ b/frontend/src/components/resources/server/stats-mini.tsx
@@ -1,12 +1,45 @@
 import { useRead } from "@lib/hooks";
 import { cn } from "@lib/utils";
 import { Progress } from "@ui/progress";
-import { Cpu, Database, MemoryStick } from "lucide-react";
+import { ServerState } from "komodo_client/dist/types";
+import { Cpu, Database, MemoryStick, LucideIcon } from "lucide-react";
 
 interface ServerStatsMiniProps {
   id: string;
   className?: string;
 }
+
+interface StatItemProps {
+  icon: LucideIcon;
+  label: string;
+  percentage: number;
+  type: "cpu" | "memory" | "disk";
+  isUnreachable: boolean;
+  getTextColor: (percentage: number, type: "cpu" | "memory" | "disk") => string;
+}
+
+const StatItem = ({ icon: Icon, label, percentage, type, isUnreachable, getTextColor }: StatItemProps) => (
+  <div className="flex items-center gap-2">
+    <Icon className="w-3 h-3 text-muted-foreground" aria-hidden="true" />
+    <div className="flex-1 min-w-0">
+      <div className="flex items-center justify-between mb-1">
+        <span className="text-xs text-muted-foreground">{label}</span>
+        <span
+          className={cn(
+            "text-xs font-medium",
+            isUnreachable ? "text-muted-foreground" : getTextColor(percentage, type)
+          )}
+        >
+          {isUnreachable ? "N/A" : `${percentage}%`}
+        </span>
+      </div>
+      <Progress
+        value={isUnreachable ? 0 : percentage}
+        className={cn("h-1", "[&>div]:transition-all")}
+      />
+    </div>
+  </div>
+);
 
 export const ServerStatsMini = ({ id, className }: ServerStatsMiniProps) => {
   const calculatePercentage = (value: number) =>
@@ -15,7 +48,6 @@ export const ServerStatsMini = ({ id, className }: ServerStatsMiniProps) => {
   const server = useRead("ListServers", {}).data?.find((s) => s.id === id);
   const serverDetails = useRead("GetServer", { server: id }).data;
   
-  // Use server-specific thresholds if available, otherwise use defaults
   const cpuWarning = serverDetails?.config?.cpu_warning ?? 75;
   const cpuCritical = serverDetails?.config?.cpu_critical ?? 90;
   const memWarning = serverDetails?.config?.mem_warning ?? 75;
@@ -40,82 +72,44 @@ export const ServerStatsMini = ({ id, className }: ServerStatsMiniProps) => {
     },
   ).data;
 
-  if (!server || server.info.state === "Disabled" || !stats) {
+  if (!server || server.info.state === "Disabled") {
     return null;
   }
 
-  const cpuPercentage = calculatePercentage(stats.cpu_perc);
-  const memoryPercentage = stats.mem_total_gb > 0 
-    ? calculatePercentage((stats.mem_used_gb / stats.mem_total_gb) * 100)
-    : 0;
+  const cpuPercentage = stats ? calculatePercentage(stats.cpu_perc) : 0;
+  const memoryPercentage = stats && stats.mem_total_gb > 0? calculatePercentage((stats.mem_used_gb / stats.mem_total_gb) * 100): 0;
 
-  const diskUsed = stats.disks.reduce((acc, disk) => acc + disk.used_gb, 0);
-  const diskTotal = stats.disks.reduce((acc, disk) => acc + disk.total_gb, 0);
-  const diskPercentage = diskTotal > 0 
-    ? calculatePercentage((diskUsed / diskTotal) * 100)
-    : 0;
+  const diskUsed = stats ? stats.disks.reduce((acc, disk) => acc + disk.used_gb, 0) : 0;
+  const diskTotal = stats ? stats.disks.reduce((acc, disk) => acc + disk.total_gb, 0) : 0;
+  const diskPercentage = diskTotal > 0? calculatePercentage((diskUsed / diskTotal) * 100): 0;
+    
+  const isUnreachable = !stats || server.info.state === ServerState.NotOk;
+  const unreachableClass = isUnreachable ? "opacity-50" : "";
+
+  const statItems = [
+    { icon: Cpu, label: "CPU", percentage: cpuPercentage, type: "cpu" as const },
+    { icon: MemoryStick, label: "Memory", percentage: memoryPercentage, type: "memory" as const },
+    { icon: Database, label: "Disk", percentage: diskPercentage, type: "disk" as const },
+  ];
 
   return (
-    <div className={cn("flex flex-col gap-2", className)}>
-      <div className="flex items-center gap-2">
-        <Cpu className="w-3 h-3 text-muted-foreground" aria-hidden="true" />
-        <div className="flex-1 min-w-0">
-          <div className="flex items-center justify-between mb-1">
-            <span className="text-xs text-muted-foreground">CPU</span>
-            <span
-              className={cn("text-xs font-medium", getTextColor(cpuPercentage, "cpu"))}
-            >
-              {cpuPercentage}%
-            </span>
-          </div>
-          <Progress
-            value={cpuPercentage}
-            className={cn("h-1", "[&>div]:transition-all")}
-          />
+    <div className={cn("flex flex-col gap-2", unreachableClass, className)}>
+      {isUnreachable && (
+        <div className="text-xs text-muted-foreground italic text-center">
+          Unreachable
         </div>
-      </div>
-
-      <div className="flex items-center gap-2">
-        <MemoryStick className="w-3 h-3 text-muted-foreground" aria-hidden="true" />
-        <div className="flex-1 min-w-0">
-          <div className="flex items-center justify-between mb-1">
-            <span className="text-xs text-muted-foreground">Memory</span>
-            <span
-              className={cn(
-                "text-xs font-medium",
-                getTextColor(memoryPercentage, "memory"),
-              )}
-            >
-              {memoryPercentage}%
-            </span>
-          </div>
-          <Progress
-            value={memoryPercentage}
-            className={cn("h-1", "[&>div]:transition-all")}
-          />
-        </div>
-      </div>
-
-      <div className="flex items-center gap-2">
-        <Database className="w-3 h-3 text-muted-foreground" aria-hidden="true" />
-        <div className="flex-1 min-w-0">
-          <div className="flex items-center justify-between mb-1">
-            <span className="text-xs text-muted-foreground">Disk</span>
-            <span
-              className={cn(
-                "text-xs font-medium",
-                getTextColor(diskPercentage, "disk"),
-              )}
-            >
-              {diskPercentage}%
-            </span>
-          </div>
-          <Progress
-            value={diskPercentage}
-            className={cn("h-1", "[&>div]:transition-all")}
-          />
-        </div>
-      </div>
+      )}
+      {statItems.map((item) => (
+        <StatItem
+          key={item.label}
+          icon={item.icon}
+          label={item.label}
+          percentage={item.percentage}
+          type={item.type}
+          isUnreachable={isUnreachable}
+          getTextColor={getTextColor}
+        />
+      ))}
     </div>
   );
 };

--- a/frontend/src/components/resources/server/stats-mini.tsx
+++ b/frontend/src/components/resources/server/stats-mini.tsx
@@ -10,14 +10,27 @@ interface ServerStatsMiniProps {
 
 export const ServerStatsMini = ({ id, className }: ServerStatsMiniProps) => {
   const calculatePercentage = (value: number) =>
-    Number((value || 0).toFixed(2));
-  const getTextColor = (percentage: number) => {
-    if (percentage >= 90) return "text-red-600";
-    if (percentage >= 75) return "text-yellow-600";
-    return "text-green-600";
-  };
+    Number((value ?? 0).toFixed(2));
 
   const server = useRead("ListServers", {}).data?.find((s) => s.id === id);
+  const serverDetails = useRead("GetServer", { server: id }).data;
+  
+  // Use server-specific thresholds if available, otherwise use defaults
+  const cpuWarning = serverDetails?.config?.cpu_warning ?? 75;
+  const cpuCritical = serverDetails?.config?.cpu_critical ?? 90;
+  const memWarning = serverDetails?.config?.mem_warning ?? 75;
+  const memCritical = serverDetails?.config?.mem_critical ?? 90;
+  const diskWarning = serverDetails?.config?.disk_warning ?? 75;
+  const diskCritical = serverDetails?.config?.disk_critical ?? 90;
+
+  const getTextColor = (percentage: number, type: "cpu" | "memory" | "disk") => {
+    const warning = type === "cpu" ? cpuWarning : type === "memory" ? memWarning : diskWarning;
+    const critical = type === "cpu" ? cpuCritical : type === "memory" ? memCritical : diskCritical;
+    
+    if (percentage >= critical) return "text-red-600";
+    if (percentage >= warning) return "text-yellow-600";
+    return "text-green-600";
+  };
   const stats = useRead(
     "GetSystemStats",
     { server: id },
@@ -32,23 +45,25 @@ export const ServerStatsMini = ({ id, className }: ServerStatsMiniProps) => {
   }
 
   const cpuPercentage = calculatePercentage(stats.cpu_perc);
-  const memoryPercentage = calculatePercentage(
-    (stats.mem_used_gb / stats.mem_total_gb) * 100,
-  );
+  const memoryPercentage = stats.mem_total_gb > 0 
+    ? calculatePercentage((stats.mem_used_gb / stats.mem_total_gb) * 100)
+    : 0;
 
   const diskUsed = stats.disks.reduce((acc, disk) => acc + disk.used_gb, 0);
   const diskTotal = stats.disks.reduce((acc, disk) => acc + disk.total_gb, 0);
-  const diskPercentage = calculatePercentage((diskUsed / diskTotal) * 100);
+  const diskPercentage = diskTotal > 0 
+    ? calculatePercentage((diskUsed / diskTotal) * 100)
+    : 0;
 
   return (
     <div className={cn("flex flex-col gap-2", className)}>
       <div className="flex items-center gap-2">
-        <Cpu className="w-3 h-3 text-muted-foreground" />
+        <Cpu className="w-3 h-3 text-muted-foreground" aria-hidden="true" />
         <div className="flex-1 min-w-0">
           <div className="flex items-center justify-between mb-1">
             <span className="text-xs text-muted-foreground">CPU</span>
             <span
-              className={cn("text-xs font-medium", getTextColor(cpuPercentage))}
+              className={cn("text-xs font-medium", getTextColor(cpuPercentage, "cpu"))}
             >
               {cpuPercentage}%
             </span>
@@ -61,14 +76,14 @@ export const ServerStatsMini = ({ id, className }: ServerStatsMiniProps) => {
       </div>
 
       <div className="flex items-center gap-2">
-        <MemoryStick className="w-3 h-3 text-muted-foreground" />
+        <MemoryStick className="w-3 h-3 text-muted-foreground" aria-hidden="true" />
         <div className="flex-1 min-w-0">
           <div className="flex items-center justify-between mb-1">
             <span className="text-xs text-muted-foreground">Memory</span>
             <span
               className={cn(
                 "text-xs font-medium",
-                getTextColor(memoryPercentage),
+                getTextColor(memoryPercentage, "memory"),
               )}
             >
               {memoryPercentage}%
@@ -82,14 +97,14 @@ export const ServerStatsMini = ({ id, className }: ServerStatsMiniProps) => {
       </div>
 
       <div className="flex items-center gap-2">
-        <Database className="w-3 h-3 text-muted-foreground" />
+        <Database className="w-3 h-3 text-muted-foreground" aria-hidden="true" />
         <div className="flex-1 min-w-0">
           <div className="flex items-center justify-between mb-1">
             <span className="text-xs text-muted-foreground">Disk</span>
             <span
               className={cn(
                 "text-xs font-medium",
-                getTextColor(diskPercentage),
+                getTextColor(diskPercentage, "disk"),
               )}
             >
               {diskPercentage}%

--- a/frontend/src/components/resources/server/stats-mini.tsx
+++ b/frontend/src/components/resources/server/stats-mini.tsx
@@ -77,11 +77,11 @@ export const ServerStatsMini = ({ id, className }: ServerStatsMiniProps) => {
   }
 
   const cpuPercentage = stats ? calculatePercentage(stats.cpu_perc) : 0;
-  const memoryPercentage = stats && stats.mem_total_gb > 0? calculatePercentage((stats.mem_used_gb / stats.mem_total_gb) * 100): 0;
+  const memoryPercentage = stats && stats.mem_total_gb > 0 ? calculatePercentage((stats.mem_used_gb / stats.mem_total_gb) * 100) : 0;
 
   const diskUsed = stats ? stats.disks.reduce((acc, disk) => acc + disk.used_gb, 0) : 0;
   const diskTotal = stats ? stats.disks.reduce((acc, disk) => acc + disk.total_gb, 0) : 0;
-  const diskPercentage = diskTotal > 0? calculatePercentage((diskUsed / diskTotal) * 100): 0;
+  const diskPercentage = diskTotal > 0? calculatePercentage((diskUsed / diskTotal) * 100) : 0;
     
   const isUnreachable = !stats || server.info.state === ServerState.NotOk;
   const unreachableClass = isUnreachable ? "opacity-50" : "";

--- a/frontend/src/lib/dashboard-preferences.ts
+++ b/frontend/src/lib/dashboard-preferences.ts
@@ -6,16 +6,14 @@ interface DashboardPreferences {
 }
 
 const DEFAULT_PREFERENCES: DashboardPreferences = {
-  showServerStats: false, // Disabled by default as requested
+  showServerStats: false,
 };
 
-// Create a global atom for dashboard preferences
 export const dashboardPreferencesAtom = atomWithStorage<DashboardPreferences>(
   "komodo-dashboard-preferences",
   DEFAULT_PREFERENCES
 );
 
-// Hook to use dashboard preferences
 export const useDashboardPreferences = () => {
   const [preferences, setPreferences] = useAtom(dashboardPreferencesAtom);
 

--- a/frontend/src/lib/dashboard-preferences.ts
+++ b/frontend/src/lib/dashboard-preferences.ts
@@ -1,0 +1,33 @@
+import { atomWithStorage } from "@lib/hooks";
+import { useAtom } from "jotai";
+
+interface DashboardPreferences {
+  showServerStats: boolean;
+}
+
+const DEFAULT_PREFERENCES: DashboardPreferences = {
+  showServerStats: false, // Disabled by default as requested
+};
+
+// Create a global atom for dashboard preferences
+export const dashboardPreferencesAtom = atomWithStorage<DashboardPreferences>(
+  "komodo-dashboard-preferences",
+  DEFAULT_PREFERENCES
+);
+
+// Hook to use dashboard preferences
+export const useDashboardPreferences = () => {
+  const [preferences, setPreferences] = useAtom(dashboardPreferencesAtom);
+
+  const updatePreference = <K extends keyof DashboardPreferences>(
+    key: K,
+    value: DashboardPreferences[K]
+  ) => {
+    setPreferences({ ...preferences, [key]: value });
+  };
+
+  return {
+    preferences,
+    updatePreference,
+  };
+};

--- a/frontend/src/pages/home/dashboard.tsx
+++ b/frontend/src/pages/home/dashboard.tsx
@@ -114,7 +114,7 @@ const ResourceRow = ({ type }: { type: UsableResource }) => {
     <div className="border rounded-md flex flex-col md:flex-row">
       <Link
         to={`/${usableResourcePath(type)}`}
-        className="shrink-0 px-6 py-4 flex flex-col justify-between lg:border-r group bg-accent/50 hover:bg-accent/15 transition-colors"
+        className="shrink-0 px-6 py-4 flex flex-col justify-center lg:border-r group bg-accent/50 hover:bg-accent/15 transition-colors"
       >
         <div className="flex items-center gap-4 text-xl group-hover:underline">
           <Components.Icon />
@@ -127,7 +127,7 @@ const ResourceRow = ({ type }: { type: UsableResource }) => {
           <History className="w-3" />
           Recently Viewed
         </p>
-        <div className="h-44 grid xl:grid-cols-2 2xl:grid-cols-3 gap-4">
+        <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-2 2xl:grid-cols-3 gap-4 auto-rows-max">
           {ids.map((id, i) => (
             <RecentCard
               key={type + id}
@@ -171,7 +171,7 @@ const RecentCard = ({
       to={`${usableResourcePath(type)}/${id}`}
       className={cn(
         "w-full px-3 py-2 border rounded-md hover:bg-accent/25 hover:-translate-y-1 transition-all flex flex-col justify-between",
-        showServerStats ? "" : "h-20",
+        showServerStats ? "min-h-32" : "h-20",
         className,
       )}
     >
@@ -185,18 +185,17 @@ const RecentCard = ({
         {type === "Stack" && <StackUpdateAvailable id={id} small />}
       </div>
 
-      {showServerStats ? (
-        <div className="flex flex-col gap-2 mt-2">
-          <ServerStatsMini id={id} />
-          <div className="flex gap-2 w-full py-2">
-            <TagsWithBadge tag_ids={tags} />
-          </div>
+      <div
+        className={cn(
+          "flex flex-col gap-2 w-full",
+          showServerStats ? "mt-2 flex-1" : "mt-auto",
+        )}
+      >
+        {showServerStats && <ServerStatsMini id={id} />}
+        <div className="flex gap-2 w-full py-1">
+          <TagsWithBadge className="flex-row" tag_ids={tags} />
         </div>
-      ) : (
-        <div className="flex gap-2 w-full">
-          <TagsWithBadge tag_ids={tags} />
-        </div>
-      )}
+      </div>
     </Link>
   );
 };

--- a/frontend/src/pages/home/dashboard.tsx
+++ b/frontend/src/pages/home/dashboard.tsx
@@ -2,6 +2,7 @@ import { ExportButton } from "@components/export";
 import { Page, Section } from "@components/layouts";
 import { ResourceComponents } from "@components/resources";
 import { ResourceLink, ResourceNameSimple } from "@components/resources/common";
+import { ServerStatsMini } from "@components/resources/server";
 import { TagsWithBadge } from "@components/tags";
 import { StatusBadge, TemplateMarker } from "@components/util";
 import {
@@ -135,7 +136,8 @@ const RecentCard = ({
     <Link
       to={`${usableResourcePath(type)}/${id}`}
       className={cn(
-        "w-full px-3 py-2 border rounded-md hover:bg-accent/25 hover:-translate-y-1 transition-all h-20 flex flex-col justify-between",
+        "w-full px-3 py-2 border rounded-md hover:bg-accent/25 hover:-translate-y-1 transition-all flex flex-col justify-between",
+        type === "Server" ? "h-32" : "h-20",
         className
       )}
     >
@@ -148,9 +150,19 @@ const RecentCard = ({
         {type === "Deployment" && <DeploymentUpdateAvailable id={id} small />}
         {type === "Stack" && <StackUpdateAvailable id={id} small />}
       </div>
-      <div className="flex gap-2 w-full">
-        <TagsWithBadge tag_ids={tags} />
-      </div>
+      
+      {type === "Server" ? (
+        <div className="flex flex-col gap-2 mt-2">
+          <ServerStatsMini id={id} />
+          <div className="flex gap-2 w-full">
+            <TagsWithBadge tag_ids={tags} />
+          </div>
+        </div>
+      ) : (
+        <div className="flex gap-2 w-full">
+          <TagsWithBadge tag_ids={tags} />
+        </div>
+      )}
     </Link>
   );
 };

--- a/frontend/src/pages/home/dashboard.tsx
+++ b/frontend/src/pages/home/dashboard.tsx
@@ -220,7 +220,7 @@ export const DashboardPieChart = ({
             <span
               className={cn(
                 "font-bold",
-                text_color_class_by_intention(intention),
+                text_color_class_by_intention(intention)
               )}
             >
               {value}
@@ -246,7 +246,7 @@ export const DashboardPieChart = ({
 const ActiveResources = () => {
   const builds =
     useRead("ListBuilds", {}).data?.filter(
-      (build) => build.info.state === Types.BuildState.Building,
+      (build) => build.info.state === Types.BuildState.Building
     ) ?? [];
   const repos =
     useRead("ListRepos", {}).data?.filter((repo) =>
@@ -254,15 +254,15 @@ const ActiveResources = () => {
         Types.RepoState.Building,
         Types.RepoState.Cloning,
         Types.RepoState.Pulling,
-      ].includes(repo.info.state),
+      ].includes(repo.info.state)
     ) ?? [];
   const procedures =
     useRead("ListProcedures", {}).data?.filter(
-      (procedure) => procedure.info.state === Types.ProcedureState.Running,
+      (procedure) => procedure.info.state === Types.ProcedureState.Running
     ) ?? [];
   const actions =
     useRead("ListActions", {}).data?.filter(
-      (action) => action.info.state === Types.ActionState.Running,
+      (action) => action.info.state === Types.ActionState.Running
     ) ?? [];
 
   const resources = [


### PR DESCRIPTION
# Problem
Currently, there’s no quick way to view all servers’ resource usage (CPU, memory, disk) in the dashboard. Users must click into each server to see these stats, which slows down monitoring.

# Changes
- [X] Added CPU%, Memory%, and Disk Usage% to each server card in the dashboard view

- [X] Implemented both desktop and mobile responsive designs

# UI Screenshots
## Desktop View

<img width="1658" height="461" alt="image" src="https://github.com/user-attachments/assets/e91391b8-d515-44f5-b460-5b96e6952b20" />

## Mobile view

<img width="381" height="792" alt="image" src="https://github.com/user-attachments/assets/24eb54bd-e60a-4fb3-8152-ad9586c25329" />


# Related Issue:
https://github.com/moghtech/komodo/issues/46