### PR TITLE
Fix podman compatibility in `get_container_stats`

### DIFF
--- a/bin/periphery/src/docker/stats.rs
+++ b/bin/periphery/src/docker/stats.rs
@@ -67,7 +67,7 @@ pub async fn get_container_stats(
                            \"MemUsage\":\"{{ .MemUsage }}\", \
                            \"Name\":\"{{ .Name }}\", \
                            \"NetIO\":\"{{ .NetIO }}\",\
-                           \"PIDs\":\"{{ .PIDs }}\"}'"
+                           \"PIDs\":\"{{ .PIDs }}\"}'";
   let container_name = match container_name {
     Some(name) => format!(" {name}"),
     None => "".to_string(),

--- a/bin/periphery/src/docker/stats.rs
+++ b/bin/periphery/src/docker/stats.rs
@@ -60,7 +60,14 @@ async fn update_container_stats() {
 pub async fn get_container_stats(
   container_name: Option<String>,
 ) -> anyhow::Result<Vec<ContainerStats>> {
-  let format = "--format \"{{ json . }}\"";
+  let format = "--format '{\"BlockIO\":\"{{ .BlockIO }}\", \
+                           \"CPUPerc\":\"{{ .CPUPerc }}\", \
+                           \"ID\":\"{{ .ID }}\", \
+                           \"MemPerc\":\"{{ .MemPerc }}\", \
+                           \"MemUsage\":\"{{ .MemUsage }}\", \
+                           \"Name\":\"{{ .Name }}\", \
+                           \"NetIO\":\"{{ .NetIO }}\",\
+                           \"PIDs\":\"{{ .PIDs }}\"}'"
   let container_name = match container_name {
     Some(name) => format!(" {name}"),
     None => "".to_string(),


### PR DESCRIPTION
By default podman stats uses different fields than docker. With this change it will use the docker formatted stats and fixes the stats display in komodo for podman hosts.