### PR TITLE
Add option to make run command detachable

### DIFF
--- a/bin/core/src/api/execute/stack.rs
+++ b/bin/core/src/api/execute/stack.rs
@@ -1033,6 +1033,7 @@ impl Resolve<ExecuteArgs> for RunStackService {
         command: self.command,
         no_tty: self.no_tty,
         no_deps: self.no_deps,
+        detach: self.detach,
         service_ports: self.service_ports,
         env: self.env,
         workdir: self.workdir,

--- a/bin/periphery/src/api/compose.rs
+++ b/bin/periphery/src/api/compose.rs
@@ -712,6 +712,7 @@ impl Resolve<super::Args> for ComposeRun {
       command,
       no_tty,
       no_deps,
+      detach,
       service_ports,
       env,
       workdir,
@@ -783,6 +784,9 @@ impl Resolve<super::Args> for ComposeRun {
     }
 
     let mut run_flags = String::from(" --rm");
+    if detach.unwrap_or_default() {
+      run_flags.push_str(" -d");
+    }
     if no_tty.unwrap_or_default() {
       run_flags.push_str(" --no-tty");
     }

--- a/client/core/rs/src/api/execute/stack.rs
+++ b/client/core/rs/src/api/execute/stack.rs
@@ -379,6 +379,9 @@ pub struct RunStackService {
   /// Do not start linked services
   #[arg(long = "no-deps", action = SetTrue)]
   pub no_deps: Option<bool>,
+  /// Detach container on run
+  #[arg(long = "detach", action = SetTrue)]
+  pub detach: Option<bool>,
   /// Map service ports to the host
   #[arg(long = "service-ports", action = SetTrue)]
   pub service_ports: Option<bool>,

--- a/client/core/ts/src/types.ts
+++ b/client/core/ts/src/types.ts
@@ -7713,6 +7713,8 @@ export interface RunStackService {
 	no_tty?: boolean;
 	/** Do not start linked services */
 	no_deps?: boolean;
+	/** Detach container on run */
+	detach?: boolean;
 	/** Map service ports to the host */
 	service_ports?: boolean;
 	/** Extra environment variables for the run */

--- a/client/periphery/rs/src/api/compose.rs
+++ b/client/periphery/rs/src/api/compose.rs
@@ -272,6 +272,9 @@ pub struct ComposeRun {
   /// Do not start linked services
   #[serde(default)]
   pub no_deps: Option<bool>,
+  /// Detach container on run
+  #[serde(default)]
+  pub detach: Option<bool>,
   /// Map service ports to the host
   #[serde(default)]
   pub service_ports: Option<bool>,

--- a/frontend/public/client/types.d.ts
+++ b/frontend/public/client/types.d.ts
@@ -7306,6 +7306,8 @@ export interface RunStackService {
     no_tty?: boolean;
     /** Do not start linked services */
     no_deps?: boolean;
+    /** Detach container on run */
+    detach?: boolean;
     /** Map service ports to the host */
     service_ports?: boolean;
     /** Extra environment variables for the run */

--- a/frontend/src/components/resources/procedure/config.tsx
+++ b/frontend/src/components/resources/procedure/config.tsx
@@ -1132,6 +1132,7 @@ const TARGET_COMPONENTS: ExecutionConfigs = {
       command: undefined,
       no_tty: undefined,
       no_deps: undefined,
+      detach: undefined,
       service_ports: undefined,
       env: undefined,
       workdir: undefined,
@@ -1151,6 +1152,7 @@ const TARGET_COMPONENTS: ExecutionConfigs = {
       );
       const [no_tty, setNoTty] = useState(!!params.no_tty);
       const [no_deps, setNoDeps] = useState(!!params.no_deps);
+      const [detach, setDetach] = useState(!!params.detach);
       const [service_ports, setServicePorts] = useState(!!params.service_ports);
       const [workdir, setWorkdir] = useState(params.workdir ?? "");
       const [user, setUser] = useState(params.user ?? "");
@@ -1175,6 +1177,7 @@ const TARGET_COMPONENTS: ExecutionConfigs = {
         );
         setNoTty(!!params.no_tty);
         setNoDeps(!!params.no_deps);
+        setDetach(!!params.detach);
         setServicePorts(!!params.service_ports);
         setWorkdir(params.workdir ?? "");
         setUser(params.user ?? "");
@@ -1216,6 +1219,7 @@ const TARGET_COMPONENTS: ExecutionConfigs = {
           user: user || undefined,
           entrypoint: entrypoint || undefined,
           pull: pull ? true : undefined,
+          detach: detach ? true : undefined,
           env,
         } as any);
         setOpen(false);
@@ -1272,6 +1276,10 @@ const TARGET_COMPONENTS: ExecutionConfigs = {
                 <label className="flex items-center gap-2">
                   <Switch checked={no_deps} onCheckedChange={setNoDeps} />
                   <span className="text-sm">No Dependencies</span>
+                </label>
+                <label className="flex items-center gap-2">
+                  <Switch checked={detach} onCheckedChange={setDetach} />
+                  <span className="text-sm">Detach</span>
                 </label>
                 <label className="flex items-center gap-2">
                   <Switch


### PR DESCRIPTION
I missed this use case in original testing, but it may occasionally be necessary to run the command in a detached state, in the event of a long running command or one where periphery may be disconnected during run.

The only downside of running detached, which is why I didn't originally include it, is that you don't have access to the logs. For this reason, it defaults to disabled (previous behavior). And if you need the logs, you can get them and follow them in the same way by the process ID returned by the run command, which is printed to stdout.

So for example in an Action,

```ts
const update = (await komodo.execute_and_poll("RunStackService", {
....
})) as Types.Update;

const pid = update.logs.find(log => log.stage === "Compose Run").stdout;
```

And then you would be able to create a terminal on that server, and execute in terminal something like `docker logs -f {pid}` to stream the logs.