### PR TITLE
Fix: Submit button remains disabled after failed API calls

### DIFF
--- a/frontend/src/components/layouts.tsx
+++ b/frontend/src/components/layouts.tsx
@@ -222,6 +222,7 @@ export const NewLayout = ({
 }) => {
   const [open, set] = useState(false);
   const [loading, setLoading] = useState(false);
+  
   return (
     <Dialog
       open={open}
@@ -248,9 +249,14 @@ export const NewLayout = ({
             variant="secondary"
             onClick={async () => {
               setLoading(true);
-              await onConfirm();
-              setLoading(false);
-              set(false);
+              try {
+                await onConfirm();
+                set(false);
+              } catch (error) {
+                console.error("Error creating resource:", error);
+              } finally {
+                setLoading(false);
+              }
             }}
             disabled={!enabled || loading}
           >


### PR DESCRIPTION
Resolves #771

## Problem
When creating a new resource with a duplicate name, the API call fails but the submit button becomes permanently disabled. Even after updating the input field with a valid name, the button stays disabled because the dialog was closing on error, preventing proper state re-evaluation.

## Root Cause
The original code called `set(false)` and `setLoading(false)` regardless of success/failure, causing the component to unmount before the `enabled={!!name}` prop could be re-evaluated.

## Solution
Added proper error handling in `NewLayout` component:
- Wrapped `onConfirm()` in try-catch block
- Only close dialog on successful API calls
- Keep dialog open on errors so users can retry
- Always reset loading state in `finally` block

## Impact
This fix applies to all resource creation flows that use the `NewResource` component, including Deployments, Stacks, Repos and Builds.
This ensures the button's enabled state is properly re-evaluated after failed operations across all resource types.