### PR TITLE
Fix confirmation dialog height overflow when selecting many stacks

### DIFF
--- a/frontend/src/components/group-actions.tsx
+++ b/frontend/src/components/group-actions.tsx
@@ -136,12 +136,12 @@ const GroupActionDialog = ({
 
   return (
     <Dialog open={!!action} onOpenChange={(o) => !o && onClose()}>
-      <DialogContent>
+      <DialogContent className="max-h-[85vh] overflow-y-auto">
         <DialogHeader>
           <DialogTitle>Group Execute - {formatted}</DialogTitle>
         </DialogHeader>
         <div className="py-8 flex flex-col gap-4">
-          <ul className="p-4 bg-accent text-sm list-disc list-inside">
+          <ul className="p-4 bg-accent text-sm list-disc list-inside max-h-[300px] overflow-y-auto">
             {selected.map((resource) => (
               <li key={resource}>{resource}</li>
             ))}


### PR DESCRIPTION
## Problem
When selecting all stacks (40+) in group actions, the confirmation dialog becomes too tall and the bottom buttons are inaccessible, requiring users to zoom out their browser to reach the confirm/cancel buttons.

## Solution
- Added `max-h-[85vh]` to dialog container to prevent overflow beyond viewport height
- Added `max-h-[300px] overflow-y-auto` to resource list for scrollable content
- Dialog footer remains always accessible regardless of selection count

Fixes #826