### PR TITLE
Fix persistent table sorting state including unsorted

### DIFF
--- a/frontend/src/ui/data-table.tsx
+++ b/frontend/src/ui/data-table.tsx
@@ -80,9 +80,7 @@ export function DataTable<TData, TValue>({
   }, [tableKey]);
 
   useEffect(() => {
-    if (sorting.length) {
-      localStorage.setItem("data-table-" + tableKey, JSON.stringify(sorting));
-    }
+    localStorage.setItem("data-table-" + tableKey, JSON.stringify(sorting));
   }, [tableKey, sorting]);
 
   useEffect(() => {


### PR DESCRIPTION
## Problem
Stack sorting preferences do not persist across page reloads. When a user sorts stacks alphabetically or reverse-alphabetically and then switches back to unsorted and navigates away or reloads the page, the sorting is lost. More specifically, when the table is in "unsorted" state (showing "-" in column header), it incorrectly reverts to the previous sorted state (e.g., reverse-alphabetical) after page reload.

## Solution
- Removed conditional check in localStorage saving logic to always persist sorting state
- Now saves empty sorting array (`[]`) for "unsorted" state instead of skipping it
- Ensures all table sorting states are consistently preserved across page reloads
- Applies to all DataTable components throughout the application

Fixes #816