### PR TITLE
1.19.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -896,7 +896,7 @@ dependencies = [
 
 [[package]]
 name = "cache"
-version = "1.19.4"
+version = "1.19.5-dev-0"
 dependencies = [
  "anyhow",
  "tokio",
@@ -1063,7 +1063,7 @@ dependencies = [
 
 [[package]]
 name = "command"
-version = "1.19.4"
+version = "1.19.5-dev-0"
 dependencies = [
  "komodo_client",
  "run_command",
@@ -1089,7 +1089,7 @@ checksum = "e47641d3deaf41fb1538ac1f54735925e275eaf3bf4d55c81b137fba797e5cbb"
 
 [[package]]
 name = "config"
-version = "1.19.4"
+version = "1.19.5-dev-0"
 dependencies = [
  "colored",
  "indexmap 2.11.1",
@@ -1330,7 +1330,7 @@ checksum = "2a2330da5de22e8a3cb63252ce2abb30116bf5265e89c0e01bc17015ce30a476"
 
 [[package]]
 name = "database"
-version = "1.19.4"
+version = "1.19.5-dev-0"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -1638,7 +1638,7 @@ dependencies = [
 
 [[package]]
 name = "environment"
-version = "1.19.4"
+version = "1.19.5-dev-0"
 dependencies = [
  "anyhow",
  "formatting",
@@ -1648,7 +1648,7 @@ dependencies = [
 
 [[package]]
 name = "environment_file"
-version = "1.19.4"
+version = "1.19.5-dev-0"
 dependencies = [
  "thiserror 2.0.16",
 ]
@@ -1744,7 +1744,7 @@ dependencies = [
 
 [[package]]
 name = "formatting"
-version = "1.19.4"
+version = "1.19.5-dev-0"
 dependencies = [
  "serror",
 ]
@@ -1906,7 +1906,7 @@ checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "git"
-version = "1.19.4"
+version = "1.19.5-dev-0"
 dependencies = [
  "anyhow",
  "cache",
@@ -2505,7 +2505,7 @@ dependencies = [
 
 [[package]]
 name = "interpolate"
-version = "1.19.4"
+version = "1.19.5-dev-0"
 dependencies = [
  "anyhow",
  "komodo_client",
@@ -2636,7 +2636,7 @@ dependencies = [
 
 [[package]]
 name = "komodo_cli"
-version = "1.19.4"
+version = "1.19.5-dev-0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2661,7 +2661,7 @@ dependencies = [
 
 [[package]]
 name = "komodo_client"
-version = "1.19.4"
+version = "1.19.5-dev-0"
 dependencies = [
  "anyhow",
  "async_timing_util",
@@ -2696,7 +2696,7 @@ dependencies = [
 
 [[package]]
 name = "komodo_core"
-version = "1.19.4"
+version = "1.19.5-dev-0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -2766,7 +2766,7 @@ dependencies = [
 
 [[package]]
 name = "komodo_periphery"
-version = "1.19.4"
+version = "1.19.5-dev-0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -2888,7 +2888,7 @@ dependencies = [
 
 [[package]]
 name = "logger"
-version = "1.19.4"
+version = "1.19.5-dev-0"
 dependencies = [
  "anyhow",
  "komodo_client",
@@ -3643,7 +3643,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "periphery_client"
-version = "1.19.4"
+version = "1.19.5-dev-0"
 dependencies = [
  "anyhow",
  "komodo_client",
@@ -4174,7 +4174,7 @@ dependencies = [
 
 [[package]]
 name = "response"
-version = "1.19.4"
+version = "1.19.5-dev-0"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -896,7 +896,7 @@ dependencies = [
 
 [[package]]
 name = "cache"
-version = "1.19.5-dev-0"
+version = "1.19.5-dev-1"
 dependencies = [
  "anyhow",
  "tokio",
@@ -1063,7 +1063,7 @@ dependencies = [
 
 [[package]]
 name = "command"
-version = "1.19.5-dev-0"
+version = "1.19.5-dev-1"
 dependencies = [
  "komodo_client",
  "run_command",
@@ -1089,7 +1089,7 @@ checksum = "e47641d3deaf41fb1538ac1f54735925e275eaf3bf4d55c81b137fba797e5cbb"
 
 [[package]]
 name = "config"
-version = "1.19.5-dev-0"
+version = "1.19.5-dev-1"
 dependencies = [
  "colored",
  "indexmap 2.11.1",
@@ -1330,7 +1330,7 @@ checksum = "2a2330da5de22e8a3cb63252ce2abb30116bf5265e89c0e01bc17015ce30a476"
 
 [[package]]
 name = "database"
-version = "1.19.5-dev-0"
+version = "1.19.5-dev-1"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -1638,7 +1638,7 @@ dependencies = [
 
 [[package]]
 name = "environment"
-version = "1.19.5-dev-0"
+version = "1.19.5-dev-1"
 dependencies = [
  "anyhow",
  "formatting",
@@ -1648,7 +1648,7 @@ dependencies = [
 
 [[package]]
 name = "environment_file"
-version = "1.19.5-dev-0"
+version = "1.19.5-dev-1"
 dependencies = [
  "thiserror 2.0.16",
 ]
@@ -1744,7 +1744,7 @@ dependencies = [
 
 [[package]]
 name = "formatting"
-version = "1.19.5-dev-0"
+version = "1.19.5-dev-1"
 dependencies = [
  "serror",
 ]
@@ -1906,7 +1906,7 @@ checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "git"
-version = "1.19.5-dev-0"
+version = "1.19.5-dev-1"
 dependencies = [
  "anyhow",
  "cache",
@@ -2505,7 +2505,7 @@ dependencies = [
 
 [[package]]
 name = "interpolate"
-version = "1.19.5-dev-0"
+version = "1.19.5-dev-1"
 dependencies = [
  "anyhow",
  "komodo_client",
@@ -2636,7 +2636,7 @@ dependencies = [
 
 [[package]]
 name = "komodo_cli"
-version = "1.19.5-dev-0"
+version = "1.19.5-dev-1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2661,7 +2661,7 @@ dependencies = [
 
 [[package]]
 name = "komodo_client"
-version = "1.19.5-dev-0"
+version = "1.19.5-dev-1"
 dependencies = [
  "anyhow",
  "async_timing_util",
@@ -2696,7 +2696,7 @@ dependencies = [
 
 [[package]]
 name = "komodo_core"
-version = "1.19.5-dev-0"
+version = "1.19.5-dev-1"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -2766,7 +2766,7 @@ dependencies = [
 
 [[package]]
 name = "komodo_periphery"
-version = "1.19.5-dev-0"
+version = "1.19.5-dev-1"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -2888,7 +2888,7 @@ dependencies = [
 
 [[package]]
 name = "logger"
-version = "1.19.5-dev-0"
+version = "1.19.5-dev-1"
 dependencies = [
  "anyhow",
  "komodo_client",
@@ -3643,7 +3643,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "periphery_client"
-version = "1.19.5-dev-0"
+version = "1.19.5-dev-1"
 dependencies = [
  "anyhow",
  "komodo_client",
@@ -4174,7 +4174,7 @@ dependencies = [
 
 [[package]]
 name = "response"
-version = "1.19.5-dev-0"
+version = "1.19.5-dev-1"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -896,7 +896,7 @@ dependencies = [
 
 [[package]]
 name = "cache"
-version = "1.19.5-dev-1"
+version = "1.19.5"
 dependencies = [
  "anyhow",
  "tokio",
@@ -1063,7 +1063,7 @@ dependencies = [
 
 [[package]]
 name = "command"
-version = "1.19.5-dev-1"
+version = "1.19.5"
 dependencies = [
  "komodo_client",
  "run_command",
@@ -1089,7 +1089,7 @@ checksum = "e47641d3deaf41fb1538ac1f54735925e275eaf3bf4d55c81b137fba797e5cbb"
 
 [[package]]
 name = "config"
-version = "1.19.5-dev-1"
+version = "1.19.5"
 dependencies = [
  "colored",
  "indexmap 2.11.1",
@@ -1330,7 +1330,7 @@ checksum = "2a2330da5de22e8a3cb63252ce2abb30116bf5265e89c0e01bc17015ce30a476"
 
 [[package]]
 name = "database"
-version = "1.19.5-dev-1"
+version = "1.19.5"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -1638,7 +1638,7 @@ dependencies = [
 
 [[package]]
 name = "environment"
-version = "1.19.5-dev-1"
+version = "1.19.5"
 dependencies = [
  "anyhow",
  "formatting",
@@ -1648,7 +1648,7 @@ dependencies = [
 
 [[package]]
 name = "environment_file"
-version = "1.19.5-dev-1"
+version = "1.19.5"
 dependencies = [
  "thiserror 2.0.16",
 ]
@@ -1744,7 +1744,7 @@ dependencies = [
 
 [[package]]
 name = "formatting"
-version = "1.19.5-dev-1"
+version = "1.19.5"
 dependencies = [
  "serror",
 ]
@@ -1906,7 +1906,7 @@ checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "git"
-version = "1.19.5-dev-1"
+version = "1.19.5"
 dependencies = [
  "anyhow",
  "cache",
@@ -2505,7 +2505,7 @@ dependencies = [
 
 [[package]]
 name = "interpolate"
-version = "1.19.5-dev-1"
+version = "1.19.5"
 dependencies = [
  "anyhow",
  "komodo_client",
@@ -2636,7 +2636,7 @@ dependencies = [
 
 [[package]]
 name = "komodo_cli"
-version = "1.19.5-dev-1"
+version = "1.19.5"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2661,7 +2661,7 @@ dependencies = [
 
 [[package]]
 name = "komodo_client"
-version = "1.19.5-dev-1"
+version = "1.19.5"
 dependencies = [
  "anyhow",
  "async_timing_util",
@@ -2696,7 +2696,7 @@ dependencies = [
 
 [[package]]
 name = "komodo_core"
-version = "1.19.5-dev-1"
+version = "1.19.5"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -2766,7 +2766,7 @@ dependencies = [
 
 [[package]]
 name = "komodo_periphery"
-version = "1.19.5-dev-1"
+version = "1.19.5"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -2888,7 +2888,7 @@ dependencies = [
 
 [[package]]
 name = "logger"
-version = "1.19.5-dev-1"
+version = "1.19.5"
 dependencies = [
  "anyhow",
  "komodo_client",
@@ -3643,7 +3643,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "periphery_client"
-version = "1.19.5-dev-1"
+version = "1.19.5"
 dependencies = [
  "anyhow",
  "komodo_client",
@@ -4174,7 +4174,7 @@ dependencies = [
 
 [[package]]
 name = "response"
-version = "1.19.5-dev-1"
+version = "1.19.5"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.package]
-version = "1.19.4"
+version = "1.19.5-dev-0"
 edition = "2024"
 authors = ["mbecker20 <becker.maxh@gmail.com>"]
 license = "GPL-3.0-or-later"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.package]
-version = "1.19.5-dev-0"
+version = "1.19.5-dev-1"
 edition = "2024"
 authors = ["mbecker20 <becker.maxh@gmail.com>"]
 license = "GPL-3.0-or-later"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.package]
-version = "1.19.5-dev-1"
+version = "1.19.5"
 edition = "2024"
 authors = ["mbecker20 <becker.maxh@gmail.com>"]
 license = "GPL-3.0-or-later"

--- a/bin/core/src/api/execute/build.rs
+++ b/bin/core/src/api/execute/build.rs
@@ -27,7 +27,7 @@ use komodo_client::{
     build::{Build, BuildConfig},
     builder::{Builder, BuilderConfig},
     deployment::DeploymentState,
-    komodo_timestamp,
+    komodo_timestamp, optional_string,
     permission::PermissionLevel,
     repo::Repo,
     update::{Log, Update},
@@ -290,12 +290,10 @@ impl Resolve<ExecuteArgs> for RunBuild {
             repo,
             registry_tokens,
             replacers: secret_replacers.into_iter().collect(),
-            // Push a commit hash tagged image
-            additional_tags: if update.commit_hash.is_empty() {
-              Default::default()
-            } else {
-              vec![update.commit_hash.clone()]
-            },
+            // To push a commit hash tagged image
+            commit_hash: optional_string(&update.commit_hash),
+            // Unused for now
+            additional_tags: Default::default(),
           }) => res.context("failed at call to periphery to build"),
         _ = cancel.cancelled() => {
           info!("build cancelled during build, cleaning up builder");

--- a/bin/core/src/api/execute/deployment.rs
+++ b/bin/core/src/api/execute/deployment.rs
@@ -12,7 +12,7 @@ use komodo_client::{
     deployment::{
       Deployment, DeploymentImage, extract_registry_domain,
     },
-    get_image_names, komodo_timestamp, optional_string,
+    komodo_timestamp, optional_string,
     permission::PermissionLevel,
     server::Server,
     update::{Log, Update},
@@ -115,7 +115,7 @@ impl Resolve<ExecuteArgs> for Deploy {
     let (version, registry_token) = match &deployment.config.image {
       DeploymentImage::Build { build_id, version } => {
         let build = resource::get::<Build>(build_id).await?;
-        let image_names = get_image_names(&build);
+        let image_names = build.get_image_names();
         let image_name = image_names
           .first()
           .context("No image name could be created")
@@ -249,7 +249,7 @@ pub async fn pull_deployment_inner(
   let (image, account, token) = match deployment.config.image {
     DeploymentImage::Build { build_id, version } => {
       let build = resource::get::<Build>(&build_id).await?;
-      let image_names = get_image_names(&build);
+      let image_names = build.get_image_names();
       let image_name = image_names
         .first()
         .context("No image name could be created")

--- a/bin/periphery/src/build.rs
+++ b/bin/periphery/src/build.rs
@@ -6,7 +6,7 @@ use std::{
 use anyhow::{Context, anyhow};
 use formatting::format_serror;
 use komodo_client::{
-  entities::{EnvironmentVar, Version, update::Log},
+  entities::{EnvironmentVar, update::Log},
   parsers::QUOTE_PATTERN,
 };
 
@@ -50,34 +50,6 @@ pub async fn write_dockerfile(
   }.await {
     logs.push(Log::error("Write Dockerfile", format_serror(&e.into())));
   }
-}
-
-pub fn image_tags(
-  image_names: &[String],
-  custom_tag: &str,
-  version: &Version,
-  additional: &[String],
-) -> anyhow::Result<String> {
-  let Version { major, minor, .. } = version;
-  let custom_tag = if custom_tag.is_empty() {
-    String::new()
-  } else {
-    format!("-{custom_tag}")
-  };
-
-  let mut res = String::new();
-
-  for image_name in image_names {
-    write!(
-      &mut res,
-      " -t {image_name}:latest{custom_tag} -t {image_name}:{version}{custom_tag} -t {image_name}:{major}.{minor}{custom_tag} -t {image_name}:{major}{custom_tag}"
-    )?;
-    for tag in additional {
-      write!(&mut res, " -t {image_name}:{tag}{custom_tag}")?;
-    }
-  }
-
-  Ok(res)
 }
 
 pub fn parse_build_args(build_args: &[EnvironmentVar]) -> String {

--- a/client/core/rs/src/entities/mod.rs
+++ b/client/core/rs/src/entities/mod.rs
@@ -5,7 +5,6 @@ use std::{
 
 use anyhow::Context;
 use async_timing_util::unix_timestamp_ms;
-use build::ImageRegistryConfig;
 use clap::Parser;
 use derive_empty_traits::EmptyTraits;
 use derive_variants::{EnumVariants, ExtractVariant};
@@ -127,54 +126,6 @@ pub fn optional_string(string: impl Into<String>) -> Option<String> {
   } else {
     Some(string)
   }
-}
-
-pub fn get_image_names(
-  build::Build {
-    name,
-    config:
-      build::BuildConfig {
-        image_name,
-        image_registry,
-        ..
-      },
-    ..
-  }: &build::Build,
-) -> Vec<String> {
-  let name = if image_name.is_empty() {
-    name
-  } else {
-    image_name
-  };
-  // Local only
-  if image_registry.is_empty() {
-    return vec![name.to_string()];
-  }
-  image_registry
-    .iter()
-    .map(
-      |ImageRegistryConfig {
-         domain,
-         account,
-         organization,
-       }| {
-        match (
-          !domain.is_empty(),
-          !organization.is_empty(),
-          !account.is_empty(),
-        ) {
-          // If organization and account provided, name under organization.
-          (true, true, true) => {
-            format!("{domain}/{organization}/{name}")
-          }
-          // Just domain / account provided
-          (true, false, true) => format!("{domain}/{account}/{name}"),
-          // Otherwise, just use name (local only)
-          _ => name.to_string(),
-        }
-      },
-    )
-    .collect()
 }
 
 pub fn to_general_name(name: &str) -> String {

--- a/client/core/ts/package.json
+++ b/client/core/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "komodo_client",
-  "version": "1.19.4",
+  "version": "1.19.5",
   "description": "Komodo client package",
   "homepage": "https://komo.do",
   "main": "dist/lib.js",

--- a/client/core/ts/src/lib.ts
+++ b/client/core/ts/src/lib.ts
@@ -199,6 +199,11 @@ export function KomodoClient(url: string, options: InitOptions) {
     } else {
       // it is a single update
       const update = res as any as Update;
+
+      if (update.status === UpdateStatus.Complete || !update._id?.$oid) {
+        return update;
+      }
+
       return await poll_update_until_complete(update._id?.$oid!);
     }
   };

--- a/client/core/ts/src/types.ts
+++ b/client/core/ts/src/types.ts
@@ -598,6 +598,12 @@ export interface BuildConfig {
 	 * independantly versioned tags.
 	 */
 	image_tag?: string;
+	/** Push `:latest` / `:latest-image_tag` tags. */
+	include_latest_tag: boolean;
+	/** Push build version semver `:1.19.5` + `1.19` / `:1.19.5-image_tag` tags. */
+	include_version_tags: boolean;
+	/** Push commit hash `:a6v8h83` / `:a6v8h83-image_tag` tags. */
+	include_commit_tag: boolean;
 	/** Configure quick links that are displayed in the resource header */
 	links?: string[];
 	/** Choose a Komodo Repo (Resource) to source the build files. */

--- a/client/periphery/rs/src/api/build.rs
+++ b/client/periphery/rs/src/api/build.rs
@@ -18,6 +18,8 @@ pub struct Build {
   /// Propogate any secret replacers from core interpolation.
   #[serde(default)]
   pub replacers: Vec<(String, String)>,
+  /// Pass the commit hash to use with tagging
+  pub commit_hash: Option<String>,
   /// Add more tags for this build in addition to the version tags.
   #[serde(default)]
   pub additional_tags: Vec<String>,

--- a/frontend/public/client/lib.js
+++ b/frontend/public/client/lib.js
@@ -88,6 +88,9 @@ export function KomodoClient(url, options) {
         else {
             // it is a single update
             const update = res;
+            if (update.status === UpdateStatus.Complete || !update._id?.$oid) {
+                return update;
+            }
             return await poll_update_until_complete(update._id?.$oid);
         }
     };

--- a/frontend/public/client/types.d.ts
+++ b/frontend/public/client/types.d.ts
@@ -595,6 +595,12 @@ export interface BuildConfig {
      * independantly versioned tags.
      */
     image_tag?: string;
+    /** Push `:latest` / `:latest-image_tag` tags. */
+    include_latest_tag: boolean;
+    /** Push build version semver `:1.19.5` + `1.19` / `:1.19.5-image_tag` tags. */
+    include_version_tags: boolean;
+    /** Push commit hash `:a6v8h83` / `:a6v8h83-image_tag` tags. */
+    include_commit_tag: boolean;
     /** Configure quick links that are displayed in the resource header */
     links?: string[];
     /** Choose a Komodo Repo (Resource) to source the build files. */

--- a/frontend/src/components/resources/build/config.tsx
+++ b/frontend/src/components/resources/build/config.tsx
@@ -163,6 +163,7 @@ export const BuildConfig = ({
 
   const version_component: ConfigComponent<Types.BuildConfig> = {
     label: "Version",
+    labelHidden: true,
     components: {
       version: (_version, set) => {
         const version =
@@ -173,6 +174,7 @@ export const BuildConfig = ({
           <ConfigInput
             className="text-lg w-[200px]"
             label="Version"
+            boldLabel
             description="Version the image with major.minor.patch. It can be interpolated using [[$VERSION]]."
             placeholder="0.0.0"
             value={version}
@@ -228,6 +230,8 @@ export const BuildConfig = ({
   };
 
   const imageName = (update.image_name ?? config.image_name) || name;
+  const customTag = update.image_tag ?? config.image_tag;
+  const customTagPostfix = customTag ? `-${customTag}` : "";
 
   const general_common: ConfigComponent<Types.BuildConfig>[] = [
     {
@@ -293,6 +297,29 @@ export const BuildConfig = ({
       },
     },
     {
+      label: "Tagging",
+      labelHidden: true,
+      components: {
+        image_name: {
+          description: "Push the image under a different name",
+          placeholder: "Custom image name",
+        },
+        image_tag: {
+          description: `Push a custom tag, plus postfix the other tags (eg ':latest-${customTag ? customTag : "<TAG>"}').`,
+          placeholder: "Custom image tag",
+        },
+        include_latest_tag: {
+          description: `:latest${customTagPostfix}`,
+        },
+        include_version_tags: {
+          description: `:X.Y.Z${customTagPostfix} + :X.Y${customTagPostfix} + :X${customTagPostfix}`,
+        },
+        include_commit_tag: {
+          description: `:ae8f8ff${customTagPostfix}`,
+        },
+      },
+    },
+    {
       label: "Links",
       labelHidden: true,
       components: {
@@ -314,19 +341,6 @@ export const BuildConfig = ({
   ];
 
   const advanced: ConfigComponent<Types.BuildConfig>[] = [
-    {
-      label: "Tagging",
-      components: {
-        image_name: {
-          description: "Push the image under a different name",
-          placeholder: "Custom image name",
-        },
-        image_tag: {
-          description: "Postfix the image version with a custom tag.",
-          placeholder: "Custom image tag",
-        },
-      },
-    },
     {
       label: "Pre Build",
       description:


### PR DESCRIPTION
# Changelog

### Resource

- **Build**: Improve image tagging customization re issues like #866
    - Push tag exactly as specified by "Image Tag"
    - Can disable `:latest` tag
    - Can disable the Version tags `:x.y.x`, `:x.y`, `:x`
    - Can disable the commit hash tag
- **Action** (and Typescript client): Fix `komodo.execute_and_poll` from error when initial update has no ID.
    - Specifically this fixed issue can happen when using `komodo.execute_and_poll("DeployStackIfChanged", {...})`.