### PR TITLE
feat: Add SOPS and Age support to Periphery

### DIFF
--- a/bin/core/debian-deps.sh
+++ b/bin/core/debian-deps.sh
@@ -3,7 +3,13 @@
 ## Core deps installer
 
 apt-get update
-apt-get install -y git curl ca-certificates iproute2
+apt-get install -y git curl ca-certificates iproute2 age
+
+# Sops only available as a binary
+SOPS_VERSION="v3.11.0"
+ARCH=$(dpkg --print-architecture)
+curl -L "https://github.com/getsops/sops/releases/download/${SOPS_VERSION}/sops-${SOPS_VERSION}.linux.${ARCH}" -o /usr/local/bin/sops
+chmod +x /usr/local/bin/sops
 
 rm -rf /var/lib/apt/lists/*
 

--- a/bin/core/debian-deps.sh
+++ b/bin/core/debian-deps.sh
@@ -6,7 +6,7 @@ apt-get update
 apt-get install -y git curl ca-certificates iproute2 age
 
 # Sops only available as a binary
-SOPS_VERSION="v3.11.0"
+SOPS_VERSION="v3.12.2"
 ARCH=$(dpkg --print-architecture)
 curl -L "https://github.com/getsops/sops/releases/download/${SOPS_VERSION}/sops-${SOPS_VERSION}.linux.${ARCH}" -o /usr/local/bin/sops
 chmod +x /usr/local/bin/sops

--- a/bin/core/debian-deps.sh
+++ b/bin/core/debian-deps.sh
@@ -3,13 +3,7 @@
 ## Core deps installer
 
 apt-get update
-apt-get install -y git curl ca-certificates iproute2 age
-
-# Sops only available as a binary
-SOPS_VERSION="v3.12.2"
-ARCH=$(dpkg --print-architecture)
-curl -L "https://github.com/getsops/sops/releases/download/${SOPS_VERSION}/sops-${SOPS_VERSION}.linux.${ARCH}" -o /usr/local/bin/sops
-chmod +x /usr/local/bin/sops
+apt-get install -y git curl ca-certificates iproute2
 
 rm -rf /var/lib/apt/lists/*
 

--- a/bin/periphery/debian-deps.sh
+++ b/bin/periphery/debian-deps.sh
@@ -3,7 +3,7 @@
 ## Periphery deps installer
 
 apt-get update
-apt-get install -y git curl wget ca-certificates
+apt-get install -y git curl wget ca-certificates age
 
 install -m 0755 -d /etc/apt/keyrings
 curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc
@@ -18,6 +18,12 @@ apt-get update
 
 # apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
 apt-get install -y docker-ce-cli docker-buildx-plugin docker-compose-plugin
+
+# Sops only available as a binary
+SOPS_VERSION="v3.11.0"
+ARCH=$(dpkg --print-architecture)
+curl -L "https://github.com/getsops/sops/releases/download/${SOPS_VERSION}/sops-${SOPS_VERSION}.linux.${ARCH}" -o /usr/local/bin/sops
+chmod +x /usr/local/bin/sops
 
 rm -rf /var/lib/apt/lists/*
 

--- a/bin/periphery/debian-deps.sh
+++ b/bin/periphery/debian-deps.sh
@@ -20,7 +20,7 @@ apt-get update
 apt-get install -y docker-ce-cli docker-buildx-plugin docker-compose-plugin
 
 # Sops only available as a binary
-SOPS_VERSION="v3.11.0"
+SOPS_VERSION="v3.12.2"
 ARCH=$(dpkg --print-architecture)
 curl -L "https://github.com/getsops/sops/releases/download/${SOPS_VERSION}/sops-${SOPS_VERSION}.linux.${ARCH}" -o /usr/local/bin/sops
 chmod +x /usr/local/bin/sops

--- a/bin/periphery/debian-deps.sh
+++ b/bin/periphery/debian-deps.sh
@@ -20,7 +20,7 @@ apt-get update
 apt-get install -y docker-ce-cli docker-buildx-plugin docker-compose-plugin
 
 # Sops only available as a binary
-SOPS_VERSION="v3.12.2"
+SOPS_VERSION="v3.13.3"
 ARCH=$(dpkg --print-architecture)
 curl -L "https://github.com/getsops/sops/releases/download/${SOPS_VERSION}/sops-${SOPS_VERSION}.linux.${ARCH}" -o /usr/local/bin/sops
 chmod +x /usr/local/bin/sops


### PR DESCRIPTION
Adding sops and age binaries to the runtime dependencies. This allows users to decrypt secrets (e.g., .env files) directly within the container for GitOps workflows, removing the need for pre-decryption scripts on the host. Will make it much easier to use sops + age based secret handling in komodo. 

Right now, we have to build docker images for core/periphery (tedious) or bind mount these binaries to the docker containers (could break). 

I tested this workflow by creating a komodo periphery image and running a stack:
Repo with periphery + sops/age is here: [Komodo Periphery Sops](https://github.com/Nikhil-Gohil/komodo-periphery-sops)

Can use this as a pre deploy for stacks in komodo assuming secrets are stored as .env.enc in git:
`sops --decrypt --input-type yaml --output-type dotenv .env.enc > .env`

One issue I can think about is this creates a slight difference between komodo periphery as a docker container and the systemd agent since it will be expected that if installing as a systemd agent, sops and age needs to be manually installed. 
