### PR TITLE
Add remove_volumes flag to Stack config

### DIFF
--- a/bin/core/src/stack/execute.rs
+++ b/bin/core/src/stack/execute.rs
@@ -194,11 +194,16 @@ impl ExecuteCompose for DestroyStack {
     } else {
       ""
     };
+    let maybe_volumes = if stack.config.remove_volumes {
+      " --volumes"
+    } else {
+      ""
+    };
     periphery
       .request(ComposeExecution {
         project: stack.project_name(false),
         command: format!(
-          "down{maybe_timeout}{maybe_remove_orphans}{service_args}"
+          "down{maybe_timeout}{maybe_remove_orphans}{maybe_volumes}{service_args}"
         ),
       })
       .await

--- a/bin/periphery/src/api/compose.rs
+++ b/bin/periphery/src/api/compose.rs
@@ -634,9 +634,14 @@ impl Resolve<super::Args> for ComposeUp {
     {
       // Take down the existing containers.
       // This one tries to use the previously deployed service name, to ensure the right stack is taken down.
-      crate::compose::down(&last_project_name, &services, &mut res)
-        .await
-        .context("failed to destroy existing containers")?;
+      crate::compose::down(
+        &last_project_name,
+        &services,
+        stack.config.remove_volumes,
+        &mut res,
+      )
+      .await
+      .context("failed to destroy existing containers")?;
     }
 
     // Run compose up

--- a/bin/periphery/src/compose/mod.rs
+++ b/bin/periphery/src/compose/mod.rs
@@ -56,6 +56,7 @@ pub fn env_file_args(
 pub async fn down(
   project: &str,
   services: &[String],
+  remove_volumes: bool,
   res: &mut ComposeUpResponse,
 ) -> anyhow::Result<()> {
   let docker_compose = docker_compose();
@@ -64,10 +65,13 @@ pub async fn down(
   } else {
     format!(" {}", services.join(" "))
   };
+  let maybe_volumes = if remove_volumes { " --volumes" } else { "" };
   let log = run_komodo_command(
     "Compose Down",
     None,
-    format!("{docker_compose} -p {project} down{service_args}"),
+    format!(
+      "{docker_compose} -p {project} down{maybe_volumes}{service_args}"
+    ),
   )
   .await;
   let success = log.success;

--- a/client/core/rs/src/entities/stack.rs
+++ b/client/core/rs/src/entities/stack.rs
@@ -503,6 +503,11 @@ pub struct StackConfig {
   #[builder(default)]
   pub build_extra_args: Vec<String>,
 
+  /// Whether to add `--volumes` flag to `docker compose down` to remove named and anonymous volumes.
+  #[serde(default)]
+  #[builder(default)]
+  pub remove_volumes: bool,
+
   /// Ignore certain services declared in the compose file when checking
   /// the stack status. For example, an init service might be exited, but the
   /// stack should be healthy. This init service should be in `ignore_services`
@@ -605,6 +610,7 @@ impl Default for StackConfig {
       run_build: Default::default(),
       destroy_before_deploy: Default::default(),
       build_extra_args: Default::default(),
+      remove_volumes: Default::default(),
       skip_secret_interp: Default::default(),
       linked_repo: Default::default(),
       git_provider: default_git_provider(),

--- a/client/core/ts/src/types.ts
+++ b/client/core/ts/src/types.ts
@@ -2258,6 +2258,10 @@ export interface StackConfig {
 	 */
 	build_extra_args?: string[];
 	/**
+	 * Whether to append `--volumes` when doing `docker compose down`.
+	 */
+	remove_volumes?: boolean;
+	/**
 	 * Ignore certain services declared in the compose file when checking
 	 * the stack status. For example, an init service might be exited, but the
 	 * stack should be healthy. This init service should be in `ignore_services`

--- a/frontend/src/components/resources/stack/config.tsx
+++ b/frontend/src/components/resources/stack/config.tsx
@@ -410,6 +410,24 @@ export const StackConfig = ({
       },
     },
     {
+      label: "Remove Volumes",
+      labelHidden: true,
+      components: {
+        remove_volumes: (value, set) => {
+          return (
+            <ConfigSwitch
+              label="Remove Volumes"
+              description="Add '--volumes' to docker compose down to remove named and anonymous volumes."
+              value={value}
+              onChange={(remove_volumes) => set({ remove_volumes })}
+              disabled={disabled}
+            />
+          );
+        },
+      },
+    },
+
+    {
       label: "Ignore Services",
       labelHidden: true,
       components: {


### PR DESCRIPTION
Adds `remove_volumes` option for Stack configuration.

If enabled adds `--volumes` flag on `docker compose down` invocation (when destroying the Stack and when re-deploying).

Ref: https://github.com/moghtech/komodo/issues/1055