### PR TITLE
Check if stack run directory is accessible

### DIFF
--- a/bin/core/src/stack/remote.rs
+++ b/bin/core/src/stack/remote.rs
@@ -36,6 +36,9 @@ pub async fn get_repo_compose_contents(
   let run_directory = repo_path.join(&stack.config.run_directory);
   // This will remove any intermediate '/./' which can be a problem for some OS.
   let run_directory = run_directory.components().collect::<PathBuf>();
+  if !run_directory.exists() {
+    anyhow::bail!("Failed to access stack run directory {stack_path:?}", stack_path = &stack.config.run_directory);
+  }
 
   let mut successful = Vec::new();
   let mut errored = Vec::new();


### PR DESCRIPTION
Intended to provide more clarity when dealing with Git stack deployment errors.

- #905

It bails when the run directory is inaccessible instead of when one of the file dependencies can't be read, to more clearly discern between various issues.