### PR TITLE
Remove usages of red for non-destructive, reversible UI

### DIFF
--- a/ui/src/components/alerts/details.tsx
+++ b/ui/src/components/alerts/details.tsx
@@ -98,7 +98,7 @@ export function AlertDetailsContent({
       {/** HEADER */}
       <Group justify="space-between">
         <Text fz="h1">{fmtUpperCamelcase(alert.data.type)}</Text>
-        <ActionIcon size="lg" variant="filled" color="red" onClick={close}>
+        <ActionIcon size="lg" variant="subtle" color="dimmed" onClick={close}>
           <ICONS.Clear size="1.3rem" />
         </ActionIcon>
       </Group>

--- a/ui/src/components/docker/container-selector.tsx
+++ b/ui/src/components/docker/container-selector.tsx
@@ -86,8 +86,8 @@ export default function ContainerSelector({
               {clearable && (
                 <ActionIcon
                   size="sm"
-                  variant="filled"
-                  color="red"
+                  variant="subtle"
+                  color="dimmed"
                   onClick={(e) => {
                     e.stopPropagation();
                     onSelect?.("");

--- a/ui/src/components/docker/link.tsx
+++ b/ui/src/components/docker/link.tsx
@@ -82,7 +82,7 @@ export const DOCKER_LINK_ICONS: {
       : noContainers
         ? ["none", "host", "bridge"].includes(name)
           ? "None"
-          : "Critical"
+          : "Neutral"
         : "Good";
     return <ICONS.Network size={size} color={hexColorByIntention(intention)} />;
   },
@@ -92,7 +92,7 @@ export const DOCKER_LINK_ICONS: {
     const noContainers = !name
       ? false
       : containers.every((container) => container.image_id !== name);
-    const intention = !name ? "Warning" : noContainers ? "Critical" : "Good";
+    const intention = !name ? "Warning" : noContainers ? "Neutral" : "Good";
     return <ICONS.Image size={size} color={hexColorByIntention(intention)} />;
   },
   Volume: ({ serverId, name, size = "1rem" }) => {
@@ -101,7 +101,7 @@ export const DOCKER_LINK_ICONS: {
     const noContainers = !name
       ? false
       : containers.every((container) => !container.volumes?.includes(name));
-    const intention = !name ? "Warning" : noContainers ? "Critical" : "Good";
+    const intention = !name ? "Warning" : noContainers ? "Neutral" : "Good";
     return <ICONS.Volume size={size} color={hexColorByIntention(intention)} />;
   },
 };

--- a/ui/src/components/log-section.tsx
+++ b/ui/src/components/log-section.tsx
@@ -135,8 +135,8 @@ export function LogSectionInner({
           {terms.map((term, index) => (
             <Button
               key={term}
-              variant="filled"
-              color="red"
+              variant="outline"
+              color="dimmed"
               rightSection={<ICONS.Remove size="1rem" />}
               onClick={() => setTerms(terms.filter((_, i) => i !== index))}
             >
@@ -157,7 +157,7 @@ export function LogSectionInner({
             rightSection={
               <ActionIcon
                 onClick={clearSearch}
-                color="red"
+                color="dimmed"
                 disabled={!terms.length}
               >
                 <ICONS.Delete size="1rem" />

--- a/ui/src/components/stack-service-selector.tsx
+++ b/ui/src/components/stack-service-selector.tsx
@@ -105,8 +105,8 @@ export default function StackServiceSelector({
               {clearable && (
                 <ActionIcon
                   size="sm"
-                  variant="filled"
-                  color="red"
+                  variant="subtle"
+                  color="dimmed"
                   onClick={(e) => {
                     e.stopPropagation();
                     onSelect?.("");

--- a/ui/src/components/tags/filter.tsx
+++ b/ui/src/components/tags/filter.tsx
@@ -14,7 +14,7 @@ export default function TagsFilter() {
     <>
       <Group gap="xs" visibleFrom="xs">
         {tags.length > 0 && (
-          <ActionIcon color="red" onClick={clear_tags} opacity={0.7}>
+          <ActionIcon color="dimmed" onClick={clear_tags}>
             <ICONS.Clear size="1rem" />{" "}
           </ActionIcon>
         )}
@@ -51,7 +51,7 @@ export default function TagsFilter() {
             />
 
             {tags.length > 0 && (
-              <ActionIcon color="red" onClick={clear_tags} opacity={0.7}>
+              <ActionIcon color="dimmed" onClick={clear_tags}>
                 <ICONS.Clear size="1rem" />{" "}
               </ActionIcon>
             )}

--- a/ui/src/components/updates/details.tsx
+++ b/ui/src/components/updates/details.tsx
@@ -86,7 +86,7 @@ export function UpdateDetailsContent({ id }: { id: string }) {
           {fmtOperation(update.operation)}{" "}
           {!versionIsNone(update.version) && fmtVersion(update.version)}
         </Text>
-        <ActionIcon size="lg" variant="filled" color="red" onClick={close}>
+        <ActionIcon size="lg" variant="subtle" color="dimmed" onClick={close}>
           <ICONS.Clear size="1.3rem" />
         </ActionIcon>
       </Group>

--- a/ui/src/pages/alerts.tsx
+++ b/ui/src/pages/alerts.tsx
@@ -139,8 +139,8 @@ export default function Alerts() {
           {/* RESET */}
           <ActionIcon
             onClick={() => setParams({})}
-            variant="filled"
-            color="red"
+            variant="subtle"
+            color="dimmed"
             disabled={!params.size}
           >
             <ICONS.Clear size="1rem" />

--- a/ui/src/pages/profile/index.tsx
+++ b/ui/src/pages/profile/index.tsx
@@ -128,7 +128,6 @@ export default function Profile() {
                   onCheckedChange={(external_skip_2fa) =>
                     updateExternalSkip2fa({ external_skip_2fa })
                   }
-                  redDisabled={false}
                 />
               )}
             </Group>

--- a/ui/src/pages/swarm/config/index.tsx
+++ b/ui/src/pages/swarm/config/index.tsx
@@ -50,7 +50,7 @@ export default function SwarmConfig() {
         intent={intent}
         state={
           !inUse && (
-            <Badge variant="filled" color="red">
+            <Badge variant="filled" color="blue">
               Unused
             </Badge>
           )

--- a/ui/src/pages/swarm/secret/index.tsx
+++ b/ui/src/pages/swarm/secret/index.tsx
@@ -50,7 +50,7 @@ export default function SwarmSecret() {
         intent={intent}
         state={
           !inUse && (
-            <Badge variant="filled" color="red">
+            <Badge variant="filled" color="blue">
               Unused
             </Badge>
           )

--- a/ui/src/pages/updates.tsx
+++ b/ui/src/pages/updates.tsx
@@ -113,8 +113,8 @@ export default function Updates() {
           {/* RESET */}
           <ActionIcon
             onClick={() => setParams({})}
-            variant="filled"
-            color="red"
+            variant="subtle"
+            color="dimmed"
             disabled={!params.size}
           >
             <ICONS.Clear size="1rem" />

--- a/ui/src/resources/alerter/index.tsx
+++ b/ui/src/resources/alerter/index.tsx
@@ -60,7 +60,7 @@ export const AlerterComponents: RequiredResourceComponents<
     const color =
       enabled === undefined || noColor
         ? undefined
-        : hexColorByIntention(enabled ? "Good" : "Critical");
+        : hexColorByIntention(enabled ? "Good" : "Neutral");
     return <ICONS.Alerter size={size} color={color} />;
   },
 
@@ -71,7 +71,7 @@ export const AlerterComponents: RequiredResourceComponents<
         type="Alerter"
         id={id}
         resource={alerter}
-        intent={alerter?.info.enabled ? "Good" : "Critical"}
+        intent={alerter?.info.enabled ? "Good" : "Neutral"}
         icon={ICONS.Alerter}
         name={alerter?.name}
         state={alerter?.info.enabled ? "Enabled" : "Disabled"}

--- a/ui/src/resources/selector.tsx
+++ b/ui/src/resources/selector.tsx
@@ -98,8 +98,8 @@ export default function ResourceSelector({
               {clearable && (
                 <ActionIcon
                   size="sm"
-                  variant="filled"
-                  color="red"
+                  variant="subtle"
+                  color="dimmed"
                   onClick={(e) => {
                     e.stopPropagation();
                     onSelect?.("");

--- a/ui/src/resources/server/docker/images.tsx
+++ b/ui/src/resources/server/docker/images.tsx
@@ -53,7 +53,7 @@ export default function ServerImages({
                 name={row.original.name}
                 id={row.original.id}
                 extra={
-                  !row.original.in_use && <Badge color="red">Unused</Badge>
+                  !row.original.in_use && <Badge color="blue">Unused</Badge>
                 }
               />
             ),

--- a/ui/src/resources/server/docker/networks.tsx
+++ b/ui/src/resources/server/docker/networks.tsx
@@ -68,7 +68,7 @@ export default function ServerNetworks({
                     ) ? (
                       <Badge>System</Badge>
                     ) : (
-                      !row.original.in_use && <Badge color="red">Unused</Badge>
+                      !row.original.in_use && <Badge color="blue">Unused</Badge>
                     )
                   }
                 />

--- a/ui/src/resources/server/docker/volumes.tsx
+++ b/ui/src/resources/server/docker/volumes.tsx
@@ -51,7 +51,7 @@ export default function ServerVolumes({
                 serverId={id}
                 name={row.original.name}
                 extra={
-                  !row.original.in_use && <Badge color="red">Unused</Badge>
+                  !row.original.in_use && <Badge color="blue">Unused</Badge>
                 }
               />
             ),

--- a/ui/src/resources/swarm/config.tsx
+++ b/ui/src/resources/swarm/config.tsx
@@ -80,7 +80,7 @@ export default function SwarmConfig({
                             clearable={false}
                           />
                           {!disabled && (
-                            <ActionIcon variant="filled" color="red">
+                            <ActionIcon variant="subtle" color="dimmed">
                               <ICONS.Remove
                                 size="1rem"
                                 onClick={() =>

--- a/ui/src/resources/swarm/docker/configs.tsx
+++ b/ui/src/resources/swarm/docker/configs.tsx
@@ -54,7 +54,7 @@ export default function SwarmConfigs({
                 name={row.original.Name}
                 extra={
                   !row.original.InUse && (
-                    <Badge variant="filled" color="red">
+                    <Badge variant="filled" color="blue">
                       Unused
                     </Badge>
                   )

--- a/ui/src/resources/swarm/docker/secrets.tsx
+++ b/ui/src/resources/swarm/docker/secrets.tsx
@@ -54,7 +54,7 @@ export default function SwarmSecrets({
                 name={row.original.Name}
                 extra={
                   !row.original.InUse && (
-                    <Badge variant="filled" color="red">
+                    <Badge variant="filled" color="blue">
                       Unused
                     </Badge>
                   )

--- a/ui/src/ui/enable-switch.tsx
+++ b/ui/src/ui/enable-switch.tsx
@@ -3,7 +3,6 @@ import { Badge, Group, GroupProps, Switch, SwitchProps } from "@mantine/core";
 export interface EnableSwitchProps extends SwitchProps {
   checked?: boolean;
   onCheckedChange?: (checked: boolean) => void;
-  redDisabled?: boolean;
   labelProps?: GroupProps;
 }
 
@@ -14,7 +13,6 @@ export default function EnableSwitch({
   onChange,
   onCheckedChange,
   disabled,
-  redDisabled = true,
   labelProps,
   ...props
 }: EnableSwitchProps) {
@@ -27,7 +25,7 @@ export default function EnableSwitch({
         <Group gap="sm" wrap="nowrap" {...labelProps}>
           {label}
           <Badge
-            color={checked ? color : redDisabled ? "red" : "gray"}
+            color={checked ? color : "gray"}
             opacity={disabled ? 0.7 : 1}
             style={{ cursor: disabled ? undefined : "pointer" }}
           >


### PR DESCRIPTION
follow up to https://github.com/moghtech/komodo/pull/1243 with the same idea, i.e. reserve red for error states and destructive actions only

Before:

<img height="200" alt="badge-before" src="https://github.com/user-attachments/assets/dd895a04-0866-4b5a-9015-59f9ed0b04a0" />

<img height="150" alt="dropdown-before" src="https://github.com/user-attachments/assets/daa4af8e-b506-4fc5-bfb1-31dfb38e5197" />

After:

<img height="200" alt="badge-after" src="https://github.com/user-attachments/assets/b607ffe5-d953-4a3e-8c5c-52102899bb1d" />


<img height="150" alt="dropdown-after" src="https://github.com/user-attachments/assets/6932245c-5fa0-4cfd-8217-c08024a19603" />


