### PR TITLE
Add container stats to stack page 

### DIFF
--- a/ui/src/components/docker/container-stats.tsx
+++ b/ui/src/components/docker/container-stats.tsx
@@ -1,0 +1,87 @@
+
+import { DataTable, SortableHeader } from "@/ui/data-table";
+
+import { Group, Text } from "@mantine/core";
+import DockerResourceLink from "@/components/docker/link";
+import { filterBySplit } from "@/lib/utils";
+import { Types } from "komodo_client";
+
+export interface ContainerStatsProps {
+    containers: Types.ContainerListItem[];
+    search: string;
+}
+
+export default function ContainerStats({containers, search}: ContainerStatsProps) {
+    const filtered = filterBySplit(
+        containers,
+        search,
+        (container) => container.name,
+    );
+    return (
+        <DataTable
+          sortDescFirst
+          mah="min(400px, calc(100vh - 320px))"
+          tableKey="container-stats"
+          data={filtered}
+          columns={[
+            {
+              accessorKey: "name",
+              size: 200,
+              header: ({ column }) => (
+                <SortableHeader column={column} title="Name" />
+              ),
+              cell: ({ row }) => (
+                <DockerResourceLink
+                  type="Container"
+                  serverId={row.original.server_id || ""}
+                  name={row.original.name}
+                />
+              ),
+            },
+            {
+              accessorKey: "stats.cpu_perc",
+              size: 100,
+              header: ({ column }) => (
+                <SortableHeader column={column} title="CPU" />
+              ),
+            },
+            {
+              accessorKey: "stats.mem_perc",
+              size: 200,
+              header: ({ column }) => (
+                <SortableHeader column={column} title="Memory" />
+              ),
+              cell: ({ row }) => (
+                <Group gap="xs">
+                  <Text>{row.original.stats?.mem_perc}</Text>
+                  <Text c="muted" size="sm">
+                    ({row.original.stats?.mem_usage})
+                  </Text>
+                </Group>
+              ),
+            },
+            {
+              accessorKey: "stats.net_io",
+              size: 150,
+              header: ({ column }) => (
+                <SortableHeader column={column} title="Net I/O" />
+              ),
+            },
+            {
+              accessorKey: "stats.block_io",
+              size: 150,
+              header: ({ column }) => (
+                <SortableHeader column={column} title="Block I/O" />
+              ),
+            },
+            {
+              accessorKey: "stats.pids",
+              size: 100,
+              header: ({ column }) => (
+                <SortableHeader column={column} title="PIDs" />
+              ),
+            },
+          ]}
+        />
+  );
+}

--- a/ui/src/resources/server/stats/containers.tsx
+++ b/ui/src/resources/server/stats/containers.tsx
@@ -1,15 +1,13 @@
 import { useRead } from "@/lib/hooks";
-import { DataTable, SortableHeader } from "@/ui/data-table";
-import Section from "@/ui/section";
-import ShowHideButton from "@/ui/show-hide-button";
-import { Group, Text } from "@mantine/core";
 import { useLocalStorage } from "@mantine/hooks";
 import { useState } from "react";
-import { filterBySplit } from "@/lib/utils";
-import DockerResourceLink from "@/components/docker/link";
 import { useIsServerAvailable } from "../hooks";
+import ContainerStats from "@/components/docker/container-stats";
 import SearchInput from "@/ui/search-input";
 import { ICONS } from "@/theme/icons";
+import Section from "@/ui/section";
+import ShowHideButton from "@/ui/show-hide-button";
+import { Group } from "@mantine/core";
 
 export default function ServerContainerStats({ id }: { id: string }) {
   const [search, setSearch] = useState("");
@@ -27,95 +25,24 @@ export default function ServerContainerStats({ id }: { id: string }) {
       enabled: isServerAvailable && show,
     },
   ).data?.filter((c) => c.stats);
-  const filtered = filterBySplit(
-    containers,
-    search,
-    (container) => container.name,
-  );
   return (
-    <Section
-      withBorder
-      title="Containers"
-      icon={<ICONS.Container size="1.3rem" />}
-      titleRight={
-        <Group ml={{ sm: "xl" }}>
-          <SearchInput
-            value={search}
-            onSearch={setSearch}
-            w={{ base: 200, lg: 300 }}
-          />
-          <ShowHideButton show={show} setShow={setShow} />
-        </Group>
-      }
-      onHeaderClick={() => setShow((s) => !s)}
-    >
-      {show && (
-        <DataTable
-          sortDescFirst
-          mah="min(400px, calc(100vh - 320px))"
-          tableKey="container-stats"
-          data={filtered}
-          columns={[
-            {
-              accessorKey: "name",
-              size: 200,
-              header: ({ column }) => (
-                <SortableHeader column={column} title="Name" />
-              ),
-              cell: ({ row }) => (
-                <DockerResourceLink
-                  type="Container"
-                  serverId={id}
-                  name={row.original.name}
-                />
-              ),
-            },
-            {
-              accessorKey: "stats.cpu_perc",
-              size: 100,
-              header: ({ column }) => (
-                <SortableHeader column={column} title="CPU" />
-              ),
-            },
-            {
-              accessorKey: "stats.mem_perc",
-              size: 200,
-              header: ({ column }) => (
-                <SortableHeader column={column} title="Memory" />
-              ),
-              cell: ({ row }) => (
-                <Group gap="xs">
-                  <Text>{row.original.stats?.mem_perc}</Text>
-                  <Text c="muted" size="sm">
-                    ({row.original.stats?.mem_usage})
-                  </Text>
-                </Group>
-              ),
-            },
-            {
-              accessorKey: "stats.net_io",
-              size: 150,
-              header: ({ column }) => (
-                <SortableHeader column={column} title="Net I/O" />
-              ),
-            },
-            {
-              accessorKey: "stats.block_io",
-              size: 150,
-              header: ({ column }) => (
-                <SortableHeader column={column} title="Block I/O" />
-              ),
-            },
-            {
-              accessorKey: "stats.pids",
-              size: 100,
-              header: ({ column }) => (
-                <SortableHeader column={column} title="PIDs" />
-              ),
-            },
-          ]}
-        />
-      )}
-    </Section>
-  );
+        <Section
+          withBorder
+          title="Containers"
+          icon={<ICONS.Container size="1.3rem" />}
+          titleRight={
+            <Group ml={{ sm: "xl" }}>
+              <SearchInput
+                value={search}
+                onSearch={setSearch}
+                w={{ base: 200, lg: 300 }}
+              />
+              <ShowHideButton show={show} setShow={setShow} />
+            </Group>
+          }
+          onHeaderClick={() => setShow((s) => !s)}
+        >
+          <ContainerStats containers={containers || []} search={search} />
+        </Section>
+  )
 }

--- a/ui/src/resources/stack/stats/container.tsx
+++ b/ui/src/resources/stack/stats/container.tsx
@@ -1,0 +1,37 @@
+import { useRead } from "@/lib/hooks";
+import { Types } from "komodo_client";
+import { ReactNode, useState } from "react";
+import { useStack } from "..";
+import ContainerStats from "@/components/docker/container-stats";
+import Section from "@/ui/section";
+import { Group } from "@mantine/core";
+import SearchInput from "@/ui/search-input";
+
+export default function StackContainerStats({ id, titleOther }: { id: string, titleOther: ReactNode }) {
+  const [search, setSearch] = useState("");
+  const isStackAvailable = useStack(id)?.info.state !== Types.StackState.Down;
+  const containers = useRead(
+    "ListStackServices",
+    {
+        stack: id,
+    },
+    {
+        enabled: isStackAvailable,
+    },
+  ).data?.map((c) => c.container).filter(c => c !== undefined);
+  return (
+      <Section titleOther={titleOther}>
+        <Section title="Container Stats" titleRight={
+                  <Group ml={{ sm: "xl" }}>
+                    <SearchInput
+                      value={search}
+                      onSearch={setSearch}
+                      w={{ base: 200, lg: 300 }}
+                    />
+                  </Group>
+                }>  
+          <ContainerStats search={search} containers={containers || []} />
+        </Section>
+    </Section>
+  )
+}

--- a/ui/src/resources/stack/tabs.tsx
+++ b/ui/src/resources/stack/tabs.tsx
@@ -16,8 +16,9 @@ import StackInfo from "./info";
 import StackServices from "./services";
 import StackLog from "./log";
 import TerminalSection from "@/components/terminal/section";
+import StackContainerStats from "./stats/container";
 
-type StackTabsView = "Config" | "Info" | "Services" | "Log" | "Terminals";
+type StackTabsView = "Config" | "Info" | "Services" | "Log" | "Terminals" | "Stats";
 
 export default function StackTabs({ id }: { id: string }) {
   const [_view, setView] = useLocalStorage<StackTabsView>({
@@ -87,6 +88,10 @@ export default function StackTabs({ id }: { id: string }) {
         hidden: !specificTerminal,
         icon: ICONS.Terminal,
       },
+      {
+        value: "Stats",
+        icon: ICONS.Stats,
+      },
     ],
     [
       hideInfo,
@@ -138,6 +143,9 @@ export default function StackTabs({ id }: { id: string }) {
           titleOther={Selector}
         />
       );
+      break;
+    case "Stats":
+      View = <StackContainerStats id={id} titleOther={Selector} />;
       break;
   }
 


### PR DESCRIPTION
This pull request adds a new tab for container stats to the stack page, closing #1020.