### PR TITLE
Use `build.get_image_tags` for deployments from builds

### DIFF
--- a/bin/core/src/api/execute/deployment.rs
+++ b/bin/core/src/api/execute/deployment.rs
@@ -123,26 +123,24 @@ impl Resolve<ExecuteArgs> for Deploy {
       DeploymentImage::Build { build_id, version } => {
         let build = resource::get::<Build>(build_id).await?;
         let image_names = build.get_image_names();
-        let image_name = image_names
+        let tags = build.get_image_tags(
+          &image_names,
+          build.info.built_hash.as_deref(),
+          &vec![], // Unused for now
+        );
+        let image_name = tags
           .first()
           .context("No image name could be created")
-          .context("Failed to create image name")?;
+          .context("Failed to create image name")?
+          .clone();
         let version = if version.is_none() {
           build.config.version
         } else {
           *version
         };
-        let version_str = version.to_string();
-        // Potentially add the build image_tag postfix
-        let version_str = if build.config.image_tag.is_empty() {
-          version_str
-        } else {
-          format!("{version_str}-{}", build.config.image_tag)
-        };
         // replace image with corresponding build image.
-        deployment.config.image = DeploymentImage::Image {
-          image: format!("{image_name}:{version_str}"),
-        };
+        deployment.config.image =
+          DeploymentImage::Image { image: image_name };
         let first_registry = build
           .config
           .image_registry
@@ -308,26 +306,23 @@ pub async fn pull_deployment_inner(
   server: &Server,
 ) -> anyhow::Result<Log> {
   let (image, account, token) = match deployment.config.image {
-    DeploymentImage::Build { build_id, version } => {
+    DeploymentImage::Build {
+      build_id,
+      version: _,
+    } => {
       let build = resource::get::<Build>(&build_id).await?;
       let image_names = build.get_image_names();
-      let image_name = image_names
+      let tags = build.get_image_tags(
+        &image_names,
+        build.info.built_hash.as_deref(),
+        &vec![], // Unused for now
+      );
+      // replace image with corresponding build image.
+      let image = tags
         .first()
         .context("No image name could be created")
-        .context("Failed to create image name")?;
-      let version = if version.is_none() {
-        build.config.version.to_string()
-      } else {
-        version.to_string()
-      };
-      // Potentially add the build image_tag postfix
-      let version = if build.config.image_tag.is_empty() {
-        version
-      } else {
-        format!("{version}-{}", build.config.image_tag)
-      };
-      // replace image with corresponding build image.
-      let image = format!("{image_name}:{version}");
+        .context("Failed to create image name")?
+        .clone();
       let first_registry = build
         .config
         .image_registry

--- a/client/core/rs/src/entities/build.rs
+++ b/client/core/rs/src/entities/build.rs
@@ -109,14 +109,6 @@ impl Build {
     let mut tags = Vec::new();
 
     for image_name in image_names {
-      // Pure image tag passthrough when provided
-      if !image_tag.is_empty() {
-        tags.push(format!("{image_name}:{image_tag}"));
-      }
-      // `:latest` / `:latest-tag`
-      if *include_latest_tag {
-        tags.push(format!("{image_name}:latest{image_tag_postfix}"));
-      }
       // `:1.19.5` + `:1.19` etc. / `1.19.5-tag`
       if *include_version_tag {
         tags
@@ -129,8 +121,16 @@ impl Build {
       if *include_commit_tag && let Some(hash) = commit_hash {
         tags.push(format!("{image_name}:{hash}{image_tag_postfix}"));
       }
+      // Pure image tag passthrough when provided
+      if !image_tag.is_empty() {
+        tags.push(format!("{image_name}:{image_tag}"));
+      }
       for tag in additional {
         tags.push(format!("{image_name}:{tag}"))
+      }
+      // `:latest` / `:latest-tag`
+      if *include_latest_tag || tags.is_empty() {
+        tags.push(format!("{image_name}:latest{image_tag_postfix}"));
       }
     }
 


### PR DESCRIPTION
- Reuse `build.get_image_tags()` for building image tag for deployments
- Reorder stuff in `get_image_tags` for preserving current deployment behavior (to prefer full version tags). It's currently only used for running builds, and builder doesn't really care about the order
- Fallback to `:latest` for both builds and deployments if no other tags were added to not fail when all of the tagging options are disabled

Tried my best to test all the combinations, but I'm not very familiar with the codebase and may miss some things

Fixes #1325