### PR TITLE
feat: add query param webhook auth and fix empty body parsing

### DIFF
--- a/bin/core/src/api/listener/integrations/github.rs
+++ b/bin/core/src/api/listener/integrations/github.rs
@@ -17,6 +17,7 @@ pub struct Github;
 impl VerifySecret for Github {
   #[instrument("VerifyGithubSecret", skip_all)]
   fn verify_secret(
+    _query: &std::collections::HashMap<String, String>,
     headers: &HeaderMap,
     body: &str,
     custom_secret: &str,
@@ -53,7 +54,7 @@ struct GithubWebhookBody {
 }
 
 impl ExtractBranch for Github {
-  fn extract_branch(body: &str) -> anyhow::Result<String> {
+  fn extract_branch(_query: &std::collections::HashMap<String, String>, body: &str) -> anyhow::Result<String> {
     let branch = serde_json::from_str::<GithubWebhookBody>(body)
       .context("Failed to parse github request body")?
       .branch

--- a/bin/core/src/api/listener/integrations/gitlab.rs
+++ b/bin/core/src/api/listener/integrations/gitlab.rs
@@ -12,6 +12,7 @@ pub struct Gitlab;
 impl VerifySecret for Gitlab {
   #[instrument("VerifyGitlabSecret", skip_all)]
   fn verify_secret(
+    _query: &std::collections::HashMap<String, String>,
     headers: &HeaderMap,
     _body: &str,
     custom_secret: &str,
@@ -41,7 +42,7 @@ struct GitlabWebhookBody {
 }
 
 impl ExtractBranch for Gitlab {
-  fn extract_branch(body: &str) -> anyhow::Result<String> {
+  fn extract_branch(_query: &std::collections::HashMap<String, String>, body: &str) -> anyhow::Result<String> {
     let branch = serde_json::from_str::<GitlabWebhookBody>(body)
       .context("Failed to parse gitlab request body")?
       .branch

--- a/bin/core/src/api/listener/integrations/mod.rs
+++ b/bin/core/src/api/listener/integrations/mod.rs
@@ -1,4 +1,5 @@
 pub mod github;
 pub mod gitlab;
+pub mod query;
 
 use super::{ExtractBranch, VerifySecret};

--- a/bin/core/src/api/listener/integrations/query.rs
+++ b/bin/core/src/api/listener/integrations/query.rs
@@ -13,7 +13,6 @@ impl VerifySecret for QueryAuth {
     _body: &str,
     custom_secret: &str,
   ) -> anyhow::Result<()> {
-    // Check if '?secret=' matches our expected custom_secret
     if query.get("secret").map(|s| s.as_str()) == Some(custom_secret) {
       Ok(())
     } else {
@@ -24,8 +23,6 @@ impl VerifySecret for QueryAuth {
 
 impl ExtractBranch for QueryAuth {
   fn extract_branch(query: &std::collections::HashMap<String, String>, _body: &str) -> anyhow::Result<String> {
-    // If your generic webhook payloads don't contain branch details,
-    // you can extract it from a query param here too.
     if let Some(branch) = query.get("branch") {
       Ok(branch.to_string())
     } else {

--- a/bin/core/src/api/listener/integrations/query.rs
+++ b/bin/core/src/api/listener/integrations/query.rs
@@ -1,0 +1,35 @@
+use std::collections::HashMap;
+use axum::http::HeaderMap;
+use anyhow::anyhow;
+
+use crate::api::listener::{ExtractBranch, VerifySecret};
+
+pub struct QueryAuth;
+
+impl VerifySecret for QueryAuth {
+  fn verify_secret(
+    query: &HashMap<String, String>,
+    _headers: &HeaderMap,
+    _body: &str,
+    custom_secret: &str,
+  ) -> anyhow::Result<()> {
+    // Check if '?secret=' matches our expected custom_secret
+    if query.get("secret").map(|s| s.as_str()) == Some(custom_secret) {
+      Ok(())
+    } else {
+      Err(anyhow!("Invalid or missing 'secret' query parameter"))
+    }
+  }
+}
+
+impl ExtractBranch for QueryAuth {
+  fn extract_branch(query: &std::collections::HashMap<String, String>, _body: &str) -> anyhow::Result<String> {
+    // If your generic webhook payloads don't contain branch details,
+    // you can extract it from a query param here too.
+    if let Some(branch) = query.get("branch") {
+      Ok(branch.to_string())
+    } else {
+      Ok("main".to_string())
+    }
+  }
+}

--- a/bin/core/src/api/listener/mod.rs
+++ b/bin/core/src/api/listener/mod.rs
@@ -18,6 +18,7 @@ pub fn router() -> Router {
   Router::new()
     .nest("/github", router::router::<github::Github>())
     .nest("/gitlab", router::router::<gitlab::Gitlab>())
+    .nest("/query", router::router::<query::QueryAuth>())
 }
 
 type ListenerLockCache = CloneCache<String, Arc<Mutex<()>>>;
@@ -32,6 +33,7 @@ trait CustomSecret: KomodoResource {
 /// Implemented on the integration struct, eg [integrations::github::Github]
 trait VerifySecret {
   fn verify_secret(
+    query: &std::collections::HashMap<String, String>,
     headers: &HeaderMap,
     body: &str,
     custom_secret: &str,
@@ -40,9 +42,9 @@ trait VerifySecret {
 
 /// Implemented on the integration struct, eg [integrations::github::Github]
 trait ExtractBranch {
-  fn extract_branch(body: &str) -> anyhow::Result<String>;
-  fn verify_branch(body: &str, expected: &str) -> anyhow::Result<()> {
-    let branch = Self::extract_branch(body)?;
+  fn extract_branch(query: &std::collections::HashMap<String, String>, body: &str) -> anyhow::Result<String>;
+  fn verify_branch(query: &std::collections::HashMap<String, String>, body: &str, expected: &str) -> anyhow::Result<()> {
+    let branch = Self::extract_branch(query, body)?;
     if branch == expected {
       Ok(())
     } else {

--- a/bin/core/src/api/listener/resources.rs
+++ b/bin/core/src/api/listener/resources.rs
@@ -43,6 +43,7 @@ fn build_locks() -> &'static ListenerLockCache {
 }
 
 pub async fn handle_build_webhook<B: super::ExtractBranch>(
+  query: &std::collections::HashMap<String, String>,
   build: Build,
   body: String,
 ) -> anyhow::Result<()> {
@@ -67,7 +68,7 @@ pub async fn handle_build_webhook<B: super::ExtractBranch>(
       .branch
   };
 
-  B::verify_branch(&body, &branch)?;
+  B::verify_branch(query, &body, &branch)?;
 
   let user = git_webhook_user().to_owned();
   let req = ExecuteRequest::RunBuild(RunBuild { build: build.id });
@@ -186,19 +187,20 @@ pub enum RepoWebhookOption {
 }
 
 pub async fn handle_repo_webhook<B: super::ExtractBranch>(
+  query: &std::collections::HashMap<String, String>,
   option: RepoWebhookOption,
   repo: Repo,
   body: String,
 ) -> anyhow::Result<()> {
   match option {
     RepoWebhookOption::Clone => {
-      handle_repo_webhook_inner::<B, CloneRepo>(repo, body).await
+      handle_repo_webhook_inner::<B, CloneRepo>(query, repo, body).await
     }
     RepoWebhookOption::Pull => {
-      handle_repo_webhook_inner::<B, PullRepo>(repo, body).await
+      handle_repo_webhook_inner::<B, PullRepo>(query, repo, body).await
     }
     RepoWebhookOption::Build => {
-      handle_repo_webhook_inner::<B, BuildRepo>(repo, body).await
+      handle_repo_webhook_inner::<B, BuildRepo>(query, repo, body).await
     }
   }
 }
@@ -207,6 +209,7 @@ async fn handle_repo_webhook_inner<
   B: super::ExtractBranch,
   E: RepoExecution,
 >(
+  query: &std::collections::HashMap<String, String>,
   repo: Repo,
   body: String,
 ) -> anyhow::Result<()> {
@@ -220,7 +223,7 @@ async fn handle_repo_webhook_inner<
   let lock = repo_locks().get_or_insert_default(&repo.id).await;
   let _lock = lock.lock().await;
 
-  B::verify_branch(&body, &repo.config.branch)?;
+  B::verify_branch(query, &body, &repo.config.branch)?;
 
   E::resolve(repo).await
 }
@@ -308,17 +311,18 @@ pub enum StackWebhookOption {
 }
 
 pub async fn handle_stack_webhook<B: super::ExtractBranch>(
+  query: &std::collections::HashMap<String, String>,
   option: StackWebhookOption,
   stack: Stack,
   body: String,
 ) -> anyhow::Result<()> {
   match option {
     StackWebhookOption::Refresh => {
-      handle_stack_webhook_inner::<B, RefreshStackCache>(stack, body)
+      handle_stack_webhook_inner::<B, RefreshStackCache>(query, stack, body)
         .await
     }
     StackWebhookOption::Deploy => {
-      handle_stack_webhook_inner::<B, DeployStack>(stack, body).await
+      handle_stack_webhook_inner::<B, DeployStack>(query, stack, body).await
     }
   }
 }
@@ -327,6 +331,7 @@ pub async fn handle_stack_webhook_inner<
   B: super::ExtractBranch,
   E: StackExecution,
 >(
+  query: &std::collections::HashMap<String, String>,
   stack: Stack,
   body: String,
 ) -> anyhow::Result<()> {
@@ -351,7 +356,7 @@ pub async fn handle_stack_webhook_inner<
       .branch
   };
 
-  B::verify_branch(&body, &branch)?;
+  B::verify_branch(query, &body, &branch)?;
 
   E::resolve(stack).await.map_err(|e| e.error)
 }
@@ -419,6 +424,7 @@ pub enum SyncWebhookOption {
 }
 
 pub async fn handle_sync_webhook<B: super::ExtractBranch>(
+  query: &std::collections::HashMap<String, String>,
   option: SyncWebhookOption,
   sync: ResourceSync,
   body: String,
@@ -426,12 +432,12 @@ pub async fn handle_sync_webhook<B: super::ExtractBranch>(
   match option {
     SyncWebhookOption::Refresh => {
       handle_sync_webhook_inner::<B, RefreshResourceSyncPending>(
-        sync, body,
+        query, sync, body,
       )
       .await
     }
     SyncWebhookOption::Sync => {
-      handle_sync_webhook_inner::<B, RunSync>(sync, body).await
+      handle_sync_webhook_inner::<B, RunSync>(query, sync, body).await
     }
   }
 }
@@ -440,6 +446,7 @@ async fn handle_sync_webhook_inner<
   B: super::ExtractBranch,
   E: SyncExecution,
 >(
+  query: &std::collections::HashMap<String, String>,
   sync: ResourceSync,
   body: String,
 ) -> anyhow::Result<()> {
@@ -464,7 +471,7 @@ async fn handle_sync_webhook_inner<
       .branch
   };
 
-  B::verify_branch(&body, &branch)?;
+  B::verify_branch(query, &body, &branch)?;
 
   E::resolve(sync).await
 }
@@ -486,6 +493,7 @@ fn procedure_locks() -> &'static ListenerLockCache {
 }
 
 pub async fn handle_procedure_webhook<B: super::ExtractBranch>(
+  query: &std::collections::HashMap<String, String>,
   procedure: Procedure,
   target_branch: &str,
   body: String,
@@ -502,7 +510,7 @@ pub async fn handle_procedure_webhook<B: super::ExtractBranch>(
   let _lock = lock.lock().await;
 
   if target_branch != ANY_BRANCH {
-    B::verify_branch(&body, target_branch)?;
+    B::verify_branch(query, &body, target_branch)?;
   }
 
   let user = git_webhook_user().to_owned();
@@ -540,6 +548,7 @@ fn action_locks() -> &'static ListenerLockCache {
 }
 
 pub async fn handle_action_webhook<B: super::ExtractBranch>(
+  query: &std::collections::HashMap<String, String>,
   action: Action,
   target_branch: &str,
   body: String,
@@ -554,7 +563,7 @@ pub async fn handle_action_webhook<B: super::ExtractBranch>(
   let lock = action_locks().get_or_insert_default(&action.id).await;
   let _lock = lock.lock().await;
 
-  let branch = B::extract_branch(&body)?;
+  let branch = B::extract_branch(query, &body)?;
 
   if target_branch != ANY_BRANCH && branch != target_branch {
     return Err(anyhow!("request branch does not match expected"));
@@ -562,8 +571,12 @@ pub async fn handle_action_webhook<B: super::ExtractBranch>(
 
   let user = git_webhook_user().to_owned();
 
-  let body = serde_json::Value::from_str(&body)
-    .context("Failed to deserialize webhook body")?;
+  let body = if body.trim().is_empty() {
+    serde_json::Value::Null
+  } else {
+    serde_json::Value::from_str(&body)
+      .context("Failed to deserialize webhook body")?
+  };
   let serde_json::Value::Object(args) = json!({
     "WEBHOOK_BRANCH": branch,
     "WEBHOOK_BODY": body,

--- a/bin/core/src/api/listener/router.rs
+++ b/bin/core/src/api/listener/router.rs
@@ -51,14 +51,14 @@ pub fn router<P: VerifySecret + ExtractBranch>() -> Router {
   .route(
     "/build/{id}",
     post(
-      |Path(Id { id }), RequestIp(ip), headers: HeaderMap, body: String| async move {
+      |Path(Id { id }), axum::extract::Query(query): axum::extract::Query<std::collections::HashMap<String, String>>, RequestIp(ip), headers: HeaderMap, body: String| async move {
         let build =
-          auth_webhook::<P, Build>(&id, &headers, ip, &body).await?;
+          auth_webhook::<P, Build>(&id, &query, &headers, ip, &body).await?;
         tokio::spawn(async move {
           let span = info_span!("BuildWebhook", id);
           async {
             let res = handle_build_webhook::<P>(
-              build, body,
+              &query, build, body,
             )
             .await;
             if let Err(e) = res {
@@ -77,14 +77,14 @@ pub fn router<P: VerifySecret + ExtractBranch>() -> Router {
   .route(
     "/repo/{id}/{option}",
     post(
-      |Path(IdAndOption::<RepoWebhookOption> { id, option }), RequestIp(ip), headers: HeaderMap, body: String| async move {
+      |Path(IdAndOption::<RepoWebhookOption> { id, option }), axum::extract::Query(query): axum::extract::Query<std::collections::HashMap<String, String>>, RequestIp(ip), headers: HeaderMap, body: String| async move {
         let repo =
-          auth_webhook::<P, Repo>(&id, &headers, ip, &body).await?;
+          auth_webhook::<P, Repo>(&id, &query, &headers, ip, &body).await?;
         tokio::spawn(async move {
           let span = info_span!("RepoWebhook", id);
           async {
             let res = handle_repo_webhook::<P>(
-              option, repo, body,
+              &query, option, repo, body,
             )
             .await;
             if let Err(e) = res {
@@ -103,14 +103,14 @@ pub fn router<P: VerifySecret + ExtractBranch>() -> Router {
   .route(
     "/stack/{id}/{option}",
     post(
-      |Path(IdAndOption::<StackWebhookOption> { id, option }), RequestIp(ip), headers: HeaderMap, body: String| async move {
+      |Path(IdAndOption::<StackWebhookOption> { id, option }), axum::extract::Query(query): axum::extract::Query<std::collections::HashMap<String, String>>, RequestIp(ip), headers: HeaderMap, body: String| async move {
         let stack =
-          auth_webhook::<P, Stack>(&id, &headers, ip, &body).await?;
+          auth_webhook::<P, Stack>(&id, &query, &headers, ip, &body).await?;
         tokio::spawn(async move {
           let span = info_span!("StackWebhook", id);
           async {
             let res = handle_stack_webhook::<P>(
-              option, stack, body,
+              &query, option, stack, body,
             )
             .await;
             if let Err(e) = res {
@@ -129,14 +129,14 @@ pub fn router<P: VerifySecret + ExtractBranch>() -> Router {
   .route(
     "/sync/{id}/{option}",
     post(
-      |Path(IdAndOption::<SyncWebhookOption> { id, option }), RequestIp(ip), headers: HeaderMap, body: String| async move {
+      |Path(IdAndOption::<SyncWebhookOption> { id, option }), axum::extract::Query(query): axum::extract::Query<std::collections::HashMap<String, String>>, RequestIp(ip), headers: HeaderMap, body: String| async move {
         let sync =
-          auth_webhook::<P, ResourceSync>(&id, &headers, ip, &body).await?;
+          auth_webhook::<P, ResourceSync>(&id, &query, &headers, ip, &body).await?;
         tokio::spawn(async move {
           let span = info_span!("ResourceSyncWebhook", id);
           async {
             let res = handle_sync_webhook::<P>(
-              option, sync, body,
+              &query, option, sync, body,
             )
             .await;
             if let Err(e) = res {
@@ -155,14 +155,14 @@ pub fn router<P: VerifySecret + ExtractBranch>() -> Router {
   .route(
     "/procedure/{id}/{branch}",
     post(
-      |Path(IdAndBranch { id, branch }), RequestIp(ip), headers: HeaderMap, body: String| async move {
+      |Path(IdAndBranch { id, branch }), axum::extract::Query(query): axum::extract::Query<std::collections::HashMap<String, String>>, RequestIp(ip), headers: HeaderMap, body: String| async move {
         let procedure =
-          auth_webhook::<P, Procedure>(&id, &headers, ip, &body).await?;
+          auth_webhook::<P, Procedure>(&id, &query, &headers, ip, &body).await?;
         tokio::spawn(async move {
           let span = info_span!("ProcedureWebhook", id);
           async {
             let res = handle_procedure_webhook::<P>(
-              procedure, &branch, body,
+              &query, procedure, &branch, body,
             )
             .await;
             if let Err(e) = res {
@@ -181,14 +181,14 @@ pub fn router<P: VerifySecret + ExtractBranch>() -> Router {
   .route(
     "/action/{id}/{branch}",
     post(
-      |Path(IdAndBranch { id, branch }), RequestIp(ip), headers: HeaderMap, body: String| async move {
+      |Path(IdAndBranch { id, branch }), axum::extract::Query(query): axum::extract::Query<std::collections::HashMap<String, String>>, RequestIp(ip), headers: HeaderMap, body: String| async move {
         let action =
-          auth_webhook::<P, Action>(&id, &headers, ip, &body).await?;
+          auth_webhook::<P, Action>(&id, &query, &headers, ip, &body).await?;
         tokio::spawn(async move {
           let span = info_span!("ActionWebhook", id);
           async {
             let res = handle_action_webhook::<P>(
-              action, &branch, body,
+              &query, action, &branch, body,
             )
             .await;
             if let Err(e) = res {
@@ -208,6 +208,7 @@ pub fn router<P: VerifySecret + ExtractBranch>() -> Router {
 
 async fn auth_webhook<P, R>(
   id: &str,
+  query: &std::collections::HashMap<String, String>,
   headers: &HeaderMap,
   ip: IpAddr,
   body: &str,
@@ -220,7 +221,7 @@ where
     let resource = crate::resource::get::<R>(id)
       .await
       .status_code(StatusCode::BAD_REQUEST)?;
-    P::verify_secret(headers, body, R::custom_secret(&resource))
+    P::verify_secret(query, headers, body, R::custom_secret(&resource))
       .status_code(StatusCode::UNAUTHORIZED)?;
 
     info!(

--- a/ui/src/components/webhook/builder.tsx
+++ b/ui/src/components/webhook/builder.tsx
@@ -30,7 +30,7 @@ export default function WebhookBuilder({
             integration &&
             setIntegration(gitProvider, integration as WebhookIntegration)
           }
-          data={["Github", "Gitlab"]}
+          data={["Github", "Gitlab", "Query"]}
           w={{ base: "100%", sm: 200 }}
         />
         <Select

--- a/ui/src/components/webhook/copy-url.tsx
+++ b/ui/src/components/webhook/copy-url.tsx
@@ -1,5 +1,6 @@
 import { useRead, WebhookIntegration } from "@/lib/hooks";
 import { ConfigItem, ConfigItemProps } from "@/ui/config/item";
+import { Text } from "@mantine/core";
 import CopyText from "@/ui/copy-text";
 
 export interface CopyWebhookUrlProps extends Omit<ConfigItemProps, "children"> {
@@ -13,9 +14,20 @@ export default function CopyWebhookUrl({
   ...itemProps
 }: CopyWebhookUrlProps) {
   const baseUrl = useRead("GetCoreInfo", {}).data?.webhook_base_url;
-  const url = baseUrl + "/listener/" + integration.toLowerCase() + path;
+  let url = baseUrl + "/listener/" + integration.toLowerCase() + path;
+  
+  let description = undefined;
+  if (integration === "Query") {
+    url += "?secret=YOUR_SECRET_HERE";
+    description = (
+      <Text size="sm" c="dimmed">
+        Requires <code>?secret=...</code> to match the configured webhook secret. Optionally supports <code>&branch=...</code> to trigger on a specific branch (defaults to main).
+      </Text>
+    );
+  }
+
   return (
-    <ConfigItem label="Webhook URL" {...itemProps}>
+    <ConfigItem label="Webhook URL" description={description} {...itemProps}>
       <CopyText content={url} />
     </ConfigItem>
   );

--- a/ui/src/lib/hooks.ts
+++ b/ui/src/lib/hooks.ts
@@ -490,7 +490,7 @@ export function useCtrlKeyListener(listenKey: string, onPress: () => void) {
   useKeyListener(listenKey, onPress, "ctrl");
 }
 
-export type WebhookIntegration = "Github" | "Gitlab";
+export type WebhookIntegration = "Github" | "Gitlab" | "Query";
 export type WebhookIntegrations = {
   [key: string]: WebhookIntegration;
 };


### PR DESCRIPTION
This PR introduces a new `Query` webhook authentication style and resolves an issue with empty webhook payloads. 

**Changes:**
- **Query Webhook Authentication:** Added a new webhook integration (`QueryAuth`) that allows external services to authenticate using a `?secret=...` query parameter instead of HTTP headers. It also optionally supports extracting the target branch via a `?branch=...` parameter (defaults to `main`).
- **Listener Infrastructure Updates:** Updated the `VerifySecret` and `ExtractBranch` traits across the router to receive the parsed query map, passing it down to all webhook handlers.
- **Empty Body Fix:** Fixed a bug where `Action` webhooks would fail with an `EOF while parsing a value` error if triggered with an empty request body. It now safely defaults to a `Null` JSON value when the body is empty.
- **UI Enhancements:** Added the new `Query` auth style to the UI dropdown options. When selected, the UI now displays helpful usage text underneath the Webhook URL field explaining the required secret and optional branch parameters.