### PR TITLE
[bug fix] pass docker login token via stdin

### DIFF
--- a/bin/core/src/network.rs
+++ b/bin/core/src/network.rs
@@ -259,9 +259,10 @@ async fn set_default_gateway(
     ));
   }
 
-  // Remove existing default routes
-  let remove_default = Command::new("sh")
-    .args(["-c", "ip route del default 2>/dev/null || true"])
+  // Remove existing default routes. Failure is ignored because the route may
+  // not exist yet.
+  let remove_default = Command::new("ip")
+    .args(["route", "del", "default"])
     .output()
     .await;
 
@@ -272,13 +273,21 @@ async fn set_default_gateway(
   }
 
   // Add new default route
-  let add_default_cmd = format!(
-    "ip route add default via {gateway} dev {interface_name}"
+  trace!(
+    "Adding default route: ip route add default via {} dev {}",
+    gateway, interface_name
   );
-  trace!("Adding default route: {}", add_default_cmd);
 
-  let add_default = Command::new("sh")
-    .args(["-c", &add_default_cmd])
+  let add_default = Command::new("ip")
+    .args([
+      "route",
+      "add",
+      "default",
+      "via",
+      gateway,
+      "dev",
+      interface_name,
+    ])
     .output()
     .await
     .context("Failed to add default route")?;
@@ -302,10 +311,23 @@ async fn set_default_gateway(
 /// Check if we have sufficient network privileges
 async fn check_network_privileges() -> bool {
   // Try to test NET_ADMIN capability with a harmless route operation
-  let capability_test = Command::new("sh")
-        .args(["-c", "ip route add 198.51.100.1/32 dev lo 2>/dev/null && ip route del 198.51.100.1/32 dev lo 2>/dev/null"])
-        .output()
-        .await;
+  let add_test = Command::new("ip")
+    .args(["route", "add", "198.51.100.1/32", "dev", "lo"])
+    .output()
+    .await;
 
-  matches!(capability_test, Ok(output) if output.status.success())
+  let Ok(output) = add_test else {
+    return false;
+  };
+
+  if !output.status.success() {
+    return false;
+  }
+
+  let del_test = Command::new("ip")
+    .args(["route", "del", "198.51.100.1/32", "dev", "lo"])
+    .output()
+    .await;
+
+  matches!(del_test, Ok(output) if output.status.success())
 }

--- a/bin/periphery/src/api/build/mod.rs
+++ b/bin/periphery/src/api/build/mod.rs
@@ -327,7 +327,7 @@ impl Resolve<crate::api::Args> for build::Build {
       "Docker Build",
       build_path.as_ref(),
       command,
-      KomodoCommandMode::Shell,
+      KomodoCommandMode::Standard,
       &replacers,
     )
     .instrument(span)

--- a/bin/periphery/src/api/compose.rs
+++ b/bin/periphery/src/api/compose.rs
@@ -3,7 +3,7 @@ use std::{borrow::Cow, fmt::Write, path::PathBuf};
 use anyhow::{Context, anyhow};
 use command::{
   KomodoCommandMode, run_komodo_command_with_sanitization,
-  run_komodo_shell_command, run_komodo_standard_command,
+  run_komodo_standard_command,
 };
 use formatting::format_serror;
 use git::write_commit_file;
@@ -29,7 +29,7 @@ use tracing::Instrument;
 use crate::{
   config::periphery_config,
   docker::compose::docker_compose,
-  helpers::{format_extra_args, format_log_grep},
+  helpers::{format_extra_args, run_log_search},
   stack::{
     maybe_login_registry, pull_or_clone_stack, validate_files,
     write::write_stack,
@@ -78,19 +78,35 @@ impl Resolve<crate::api::Args> for GetComposeLogSearch {
       timestamps,
     } = self;
     let docker_compose = docker_compose();
-    let grep = format_log_grep(&terms, combinator, invert);
-    let timestamps = if timestamps {
-      " --timestamps"
+    let mut args = vec![
+      "-p".to_string(),
+      project,
+      "logs".to_string(),
+      "--tail".to_string(),
+      "5000".to_string(),
+    ];
+    if timestamps {
+      args.push("--timestamps".to_string());
+    }
+    args.extend(services);
+    let (program, args) = if docker_compose == "docker compose" {
+      let mut prefixed = vec!["compose".to_string()];
+      prefixed.extend(args);
+      ("docker", prefixed)
     } else {
-      Default::default()
+      (docker_compose, args)
     };
-    let command = format!(
-      "{docker_compose} -p {project} logs --tail 5000{timestamps} {} 2>&1 | {grep}",
-      services.join(" ")
-    );
     Ok(
-      run_komodo_shell_command("Search Stack Log", None, command)
-        .await,
+      run_log_search(
+        "Search Stack Log",
+        None,
+        program,
+        args,
+        &terms,
+        combinator,
+        invert,
+      )
+      .await,
     )
   }
 }
@@ -722,7 +738,7 @@ impl Resolve<crate::api::Args> for ComposeUp {
     let command = format!(
       "{docker_compose} -p {project_name} -f {file_args}{env_file_args} up -d{extra_args}{service_args}",
     );
-    let (command, _) = match maybe_wrap_command(
+    let (command, wrapped) = match maybe_wrap_command(
       command,
       &compose_cmd_wrapper,
       wrapper_include,
@@ -735,12 +751,17 @@ impl Resolve<crate::api::Args> for ComposeUp {
       }
     };
 
+    let mode = if wrapped {
+      KomodoCommandMode::Shell
+    } else {
+      KomodoCommandMode::Standard
+    };
     let span = info_span!("ExecuteComposeUp");
     let Some(log) = run_komodo_command_with_sanitization(
       "Compose Up",
       run_directory.as_path(),
       command,
-      KomodoCommandMode::Shell,
+      mode,
       &replacers,
     )
     .instrument(span)
@@ -981,7 +1002,7 @@ impl Resolve<crate::api::Args> for ComposeRun {
     let run_command = format!(
       "{docker_compose} -p {project_name} -f {file_args}{env_file_args} run{run_flags} {service}{command_args}",
     );
-    let (run_command, _) = match maybe_wrap_command(
+    let (run_command, wrapped) = match maybe_wrap_command(
       run_command,
       &compose_cmd_wrapper,
       wrapper_include,
@@ -991,12 +1012,17 @@ impl Resolve<crate::api::Args> for ComposeRun {
       Err(log) => return Ok(log),
     };
 
+    let mode = if wrapped {
+      KomodoCommandMode::Shell
+    } else {
+      KomodoCommandMode::Standard
+    };
     let span = info_span!("RunComposeRun", run_command);
     let Some(log) = run_komodo_command_with_sanitization(
       "Compose Run",
       run_directory.as_path(),
       run_command,
-      KomodoCommandMode::Shell,
+      mode,
       &replacers,
     )
     .instrument(span)

--- a/bin/periphery/src/api/container/mod.rs
+++ b/bin/periphery/src/api/container/mod.rs
@@ -1,6 +1,6 @@
 use anyhow::Context;
 use command::{
-  run_komodo_shell_command, run_komodo_standard_command,
+  command_string, run_command_args, run_komodo_standard_command,
 };
 use futures_util::future::join_all;
 use komodo_client::entities::{
@@ -8,6 +8,7 @@ use komodo_client::entities::{
     container::{Container, ContainerListItem, ContainerStats},
     stats::FullContainerStats,
   },
+  komodo_timestamp,
   update::Log,
 };
 use mogh_resolver::Resolve;
@@ -15,7 +16,7 @@ use periphery_client::api::container::*;
 
 use crate::{
   docker::{stats::get_container_stats, stop_container_command},
-  helpers::format_log_grep,
+  helpers::run_log_search,
   state::docker_client,
 };
 
@@ -81,20 +82,24 @@ impl Resolve<crate::api::Args> for GetContainerLogSearch {
       invert,
       timestamps,
     } = self;
-    let grep = format_log_grep(&terms, combinator, invert);
-    let timestamps = if timestamps {
-      " --timestamps"
-    } else {
-      Default::default()
-    };
-    let command = format!(
-      "docker logs {name} --tail 5000{timestamps} 2>&1 | {grep}"
-    );
+    let mut args = vec![
+      "logs".to_string(),
+      name,
+      "--tail".to_string(),
+      "5000".to_string(),
+    ];
+    if timestamps {
+      args.push("--timestamps".to_string());
+    }
     Ok(
-      run_komodo_shell_command(
+      run_log_search(
         "Get container log grep",
         None,
-        command,
+        "docker",
+        args,
+        &terms,
+        combinator,
+        invert,
       )
       .await,
     )
@@ -307,25 +312,10 @@ impl Resolve<crate::api::Args> for RemoveContainer {
     args: &crate::api::Args,
   ) -> anyhow::Result<Log> {
     let RemoveContainer { name, signal, time } = self;
-    let stop_command = stop_container_command(&name, signal, time);
-    let command =
-      format!("{stop_command} && docker container rm {name}");
-    let log = run_komodo_shell_command(
-      "Docker Stop and Remove",
-      None,
-      command,
-    )
-    .await;
+    let log = stop_and_remove_container(&name, signal, time).await;
     if log.stderr.contains("unknown flag: --signal") {
-      let stop_command = stop_container_command(&name, None, time);
-      let command =
-        format!("{stop_command} && docker container rm {name}");
-      let mut log = run_komodo_shell_command(
-        "Docker Stop and Remove",
-        None,
-        command,
-      )
-      .await;
+      let mut log =
+        stop_and_remove_container(&name, None, time).await;
       log.stderr = format!(
         "Old docker version: unable to use --signal flag{}",
         if !log.stderr.is_empty() {
@@ -339,6 +329,66 @@ impl Resolve<crate::api::Args> for RemoveContainer {
       Ok(log)
     }
   }
+}
+
+async fn stop_and_remove_container(
+  name: &str,
+  signal: Option<komodo_client::entities::TerminationSignal>,
+  time: Option<i32>,
+) -> Log {
+  let stop_args = stop_container_args(name, signal, time);
+  let rm_args =
+    vec!["container".to_string(), "rm".to_string(), name.to_string()];
+  let command = format!(
+    "{} && {}",
+    command_string("docker", &stop_args),
+    command_string("docker", &rm_args)
+  );
+  let start_ts = komodo_timestamp();
+
+  let stop_output =
+    run_command_args("docker", &stop_args, None, None).await;
+  if !stop_output.success() {
+    return Log {
+      stage: "Docker Stop and Remove".to_string(),
+      stdout: stop_output.stdout,
+      stderr: stop_output.stderr,
+      command,
+      success: false,
+      start_ts,
+      end_ts: komodo_timestamp(),
+    };
+  }
+
+  let rm_output =
+    run_command_args("docker", &rm_args, None, None).await;
+  Log {
+    stage: "Docker Stop and Remove".to_string(),
+    stdout: format!("{}{}", stop_output.stdout, rm_output.stdout),
+    stderr: format!("{}{}", stop_output.stderr, rm_output.stderr),
+    command,
+    success: rm_output.success(),
+    start_ts,
+    end_ts: komodo_timestamp(),
+  }
+}
+
+fn stop_container_args(
+  name: &str,
+  signal: Option<komodo_client::entities::TerminationSignal>,
+  time: Option<i32>,
+) -> Vec<String> {
+  let mut args = vec!["stop".to_string()];
+  if let Some(signal) = signal {
+    args.push("--signal".to_string());
+    args.push(signal.to_string());
+  }
+  if let Some(time) = time {
+    args.push("--time".to_string());
+    args.push(time.to_string());
+  }
+  args.push(name.to_string());
+  args
 }
 
 //

--- a/bin/periphery/src/api/container/run.rs
+++ b/bin/periphery/src/api/container/run.rs
@@ -109,7 +109,7 @@ impl Resolve<crate::api::Args> for RunContainer {
       "Docker Run",
       None,
       command,
-      KomodoCommandMode::Shell,
+      KomodoCommandMode::Standard,
       &replacers,
     )
     .instrument(span)

--- a/bin/periphery/src/api/swarm/service.rs
+++ b/bin/periphery/src/api/swarm/service.rs
@@ -3,7 +3,7 @@ use std::fmt::Write;
 use anyhow::Context as _;
 use command::{
   KomodoCommandMode, run_komodo_command_with_sanitization,
-  run_komodo_shell_command, run_komodo_standard_command,
+  run_komodo_standard_command,
 };
 use formatting::format_serror;
 use interpolate::Interpolator;
@@ -28,8 +28,8 @@ use crate::{
   config::periphery_config,
   docker::docker_login,
   helpers::{
-    format_log_grep, push_conversions, push_environment,
-    push_extra_args, push_labels,
+    push_conversions, push_environment, push_extra_args, push_labels,
+    run_log_search,
   },
   state::docker_client,
 };
@@ -110,35 +110,34 @@ impl Resolve<crate::api::Args> for GetSwarmServiceLogSearch {
       no_resolve,
       details,
     } = self;
-    let timestamps = if timestamps {
-      " --timestamps"
-    } else {
-      Default::default()
-    };
-    let no_task_ids = if no_task_ids {
-      " --no-task-ids"
-    } else {
-      Default::default()
-    };
-    let no_resolve = if no_resolve {
-      " --no-resolve"
-    } else {
-      Default::default()
-    };
-    let details = if details {
-      " --details"
-    } else {
-      Default::default()
-    };
-    let grep = format_log_grep(&terms, combinator, invert);
-    let command = format!(
-      "docker service logs --tail 5000{timestamps}{no_task_ids}{no_resolve}{details} {service} 2>&1 | {grep}",
-    );
+    let mut args = vec![
+      "service".to_string(),
+      "logs".to_string(),
+      "--tail".to_string(),
+      "5000".to_string(),
+    ];
+    if timestamps {
+      args.push("--timestamps".to_string());
+    }
+    if no_task_ids {
+      args.push("--no-task-ids".to_string());
+    }
+    if no_resolve {
+      args.push("--no-resolve".to_string());
+    }
+    if details {
+      args.push("--details".to_string());
+    }
+    args.push(service);
     Ok(
-      run_komodo_shell_command(
+      run_log_search(
         "Search Swarm Service Log",
         None,
-        command,
+        "docker",
+        args,
+        &terms,
+        combinator,
+        invert,
       )
       .await,
     )
@@ -295,7 +294,7 @@ impl Resolve<crate::api::Args> for CreateSwarmService {
       "Docker Service Create",
       None,
       command,
-      KomodoCommandMode::Shell,
+      KomodoCommandMode::Standard,
       &replacers,
     )
     .instrument(span)

--- a/bin/periphery/src/api/swarm/stack.rs
+++ b/bin/periphery/src/api/swarm/stack.rs
@@ -307,7 +307,7 @@ impl Resolve<crate::api::Args> for DeploySwarmStack {
     write!(&mut command, " {project_name}")?;
 
     // Apply compose cmd wrapper if configured
-    let (command, _) = match maybe_wrap_command(
+    let (command, wrapped) = match maybe_wrap_command(
       command,
       &compose_cmd_wrapper,
       wrapper_include,
@@ -320,12 +320,17 @@ impl Resolve<crate::api::Args> for DeploySwarmStack {
       }
     };
 
+    let mode = if wrapped || !env_file_args.is_empty() {
+      KomodoCommandMode::Shell
+    } else {
+      KomodoCommandMode::Standard
+    };
     let span = info_span!("ExecuteStackDeploy");
     let Some(log) = run_komodo_command_with_sanitization(
       "Deploy Swarm Stack",
       run_directory.as_path(),
       command,
-      KomodoCommandMode::Shell,
+      mode,
       &replacers,
     )
     .instrument(span)

--- a/bin/periphery/src/docker/config.rs
+++ b/bin/periphery/src/docker/config.rs
@@ -2,7 +2,7 @@ use std::fmt::Write;
 
 use anyhow::{Context, anyhow};
 use command::{
-  run_komodo_shell_command, run_komodo_standard_command,
+  run_komodo_command_args_with_stdin, run_komodo_standard_command,
 };
 use data_encoding::BASE64URL;
 use futures_util::{TryStreamExt as _, stream::FuturesUnordered};
@@ -115,26 +115,29 @@ pub async fn create_swarm_config(
     template_driver,
   }: &CreateSwarmConfig,
 ) -> anyhow::Result<Log> {
-  let mut command = String::from("docker config create");
+  let mut args = vec!["config".to_string(), "create".to_string()];
 
   for label in labels {
-    write!(&mut command, " --label {label}")?;
+    args.push("--label".to_string());
+    args.push(label.to_string());
   }
 
   if let Some(driver) = template_driver {
-    write!(&mut command, " --template-driver {driver}")?;
+    args.push("--template-driver".to_string());
+    args.push(driver.to_string());
   }
 
-  write!(
-    &mut command,
-    r#" {name} - <<'EOF'
-{}
-EOF"#,
-    data.trim()
-  )?;
+  args.push(name.to_string());
+  args.push("-".to_string());
 
-  let log =
-    run_komodo_shell_command("Create Config", None, command).await;
+  let log = run_komodo_command_args_with_stdin(
+    "Create Config",
+    None,
+    "docker",
+    args,
+    data.trim(),
+  )
+  .await;
 
   Ok(log)
 }

--- a/bin/periphery/src/docker/mod.rs
+++ b/bin/periphery/src/docker/mod.rs
@@ -1,14 +1,11 @@
-use std::process::Stdio;
-
 use anyhow::{Context, anyhow};
 use bollard::Docker;
-use command::{CommandOutput, run_komodo_standard_command};
+use command::{run_command_args, run_komodo_standard_command};
 use komodo_client::entities::{
   TerminationSignal,
   docker::{task::*, *},
   update::Log,
 };
-use tokio::{io::AsyncWriteExt, process::Command};
 
 pub mod compose;
 pub mod config;
@@ -79,32 +76,22 @@ async fn docker_login_command(
   domain: &str,
   account: &str,
   registry_token: &str,
-) -> anyhow::Result<CommandOutput> {
-  let mut child = Command::new("docker")
-    .args([
-      "login",
-      domain,
-      "--username",
-      account,
-      "--password-stdin",
-    ])
-    .kill_on_drop(true)
-    .stdin(Stdio::piped())
-    .stdout(Stdio::piped())
-    .stderr(Stdio::piped())
-    .spawn()
-    .context("Failed to spawn docker login")?;
-
-  let mut stdin = child
-    .stdin
-    .take()
-    .context("Failed to open docker login stdin")?;
-  stdin.write_all(registry_token.as_bytes()).await.context(
-    "Failed to write registry token to docker login stdin",
-  )?;
-  drop(stdin);
-
-  Ok(CommandOutput::from(child.wait_with_output().await))
+) -> anyhow::Result<command::CommandOutput> {
+  Ok(
+    run_command_args(
+      "docker",
+      &[
+        "login".to_string(),
+        domain.to_string(),
+        "--username".to_string(),
+        account.to_string(),
+        "--password-stdin".to_string(),
+      ],
+      None,
+      Some(registry_token.as_bytes()),
+    )
+    .await,
+  )
 }
 
 #[instrument("PullImage")]

--- a/bin/periphery/src/docker/mod.rs
+++ b/bin/periphery/src/docker/mod.rs
@@ -1,11 +1,14 @@
+use std::process::Stdio;
+
 use anyhow::{Context, anyhow};
 use bollard::Docker;
-use command::{run_komodo_standard_command, run_shell_command};
+use command::{CommandOutput, run_komodo_standard_command};
 use komodo_client::entities::{
   TerminationSignal,
   docker::{task::*, *},
   update::Log,
 };
+use tokio::{io::AsyncWriteExt, process::Command};
 
 pub mod compose;
 pub mod config;
@@ -51,10 +54,8 @@ pub async fn docker_login(
     None => crate::helpers::registry_token(domain, account)?,
   };
 
-  let log = run_shell_command(&format!(
-    "echo {registry_token} | docker login {domain} --username '{account}' --password-stdin",
-  ), None)
-  .await;
+  let log =
+    docker_login_command(domain, account, registry_token).await?;
 
   if log.success() {
     return Ok(true);
@@ -72,6 +73,38 @@ pub async fn docker_login(
     e = e.context(line.to_string());
   }
   Err(e.context(format!("Registry {domain} login error")))
+}
+
+async fn docker_login_command(
+  domain: &str,
+  account: &str,
+  registry_token: &str,
+) -> anyhow::Result<CommandOutput> {
+  let mut child = Command::new("docker")
+    .args([
+      "login",
+      domain,
+      "--username",
+      account,
+      "--password-stdin",
+    ])
+    .kill_on_drop(true)
+    .stdin(Stdio::piped())
+    .stdout(Stdio::piped())
+    .stderr(Stdio::piped())
+    .spawn()
+    .context("Failed to spawn docker login")?;
+
+  let mut stdin = child
+    .stdin
+    .take()
+    .context("Failed to open docker login stdin")?;
+  stdin.write_all(registry_token.as_bytes()).await.context(
+    "Failed to write registry token to docker login stdin",
+  )?;
+  drop(stdin);
+
+  Ok(CommandOutput::from(child.wait_with_output().await))
 }
 
 #[instrument("PullImage")]

--- a/bin/periphery/src/docker/secret.rs
+++ b/bin/periphery/src/docker/secret.rs
@@ -3,7 +3,7 @@ use std::fmt::Write;
 use anyhow::Context;
 use bollard::query_parameters::ListSecretsOptions;
 use command::{
-  run_komodo_shell_command, run_komodo_standard_command,
+  run_komodo_command_args_with_stdin, run_komodo_standard_command,
 };
 use futures_util::{TryStreamExt as _, stream::FuturesUnordered};
 use komodo_client::entities::{
@@ -118,41 +118,34 @@ pub async fn create_swarm_secret(
     template_driver,
   }: &CreateSwarmSecret,
 ) -> anyhow::Result<Log> {
-  let mut command = String::from("docker secret create");
+  let mut args = vec!["secret".to_string(), "create".to_string()];
 
   if let Some(driver) = driver {
-    write!(&mut command, " --driver {driver}")?;
+    args.push("--driver".to_string());
+    args.push(driver.to_string());
   }
 
   for label in labels {
-    write!(&mut command, " --label {label}")?;
+    args.push("--label".to_string());
+    args.push(label.to_string());
   }
 
   if let Some(driver) = template_driver {
-    write!(&mut command, " --template-driver {driver}")?;
+    args.push("--template-driver".to_string());
+    args.push(driver.to_string());
   }
 
-  let mut sanitized_command = command.clone();
+  args.push(name.to_string());
+  args.push("-".to_string());
 
-  write!(
-    &mut command,
-    r#" {name} - <<'EOF'
-{}
-EOF"#,
-    data.trim()
-  )?;
-
-  write!(
-    &mut sanitized_command,
-    r#" {name} - <<'EOF'
-<secret-data>
-EOF"#
-  )?;
-
-  let mut log =
-    run_komodo_shell_command("Create Secret", None, command).await;
-
-  log.command = sanitized_command;
+  let log = run_komodo_command_args_with_stdin(
+    "Create Secret",
+    None,
+    "docker",
+    args,
+    data.trim(),
+  )
+  .await;
 
   Ok(log)
 }

--- a/bin/periphery/src/helpers.rs
+++ b/bin/periphery/src/helpers.rs
@@ -5,7 +5,8 @@ use std::{
 
 use anyhow::Context;
 use command::{
-  KomodoCommandMode, run_komodo_command_with_sanitization,
+  KomodoCommandMode, command_string, output_into_log,
+  run_command_args, run_komodo_command_with_sanitization,
   run_standard_command,
 };
 use environment::write_env_file;
@@ -14,7 +15,7 @@ use komodo_client::{
   entities::{
     EnvironmentVar, RepoExecutionArgs, RepoExecutionResponse,
     SearchCombinator, SystemCommand, all_logs_success,
-    deployment::Conversion,
+    deployment::Conversion, komodo_timestamp, update::Log,
   },
   parsers::QUOTE_PATTERN,
 };
@@ -113,23 +114,56 @@ pub fn push_environment(
   Ok(())
 }
 
-pub fn format_log_grep(
+pub async fn run_log_search(
+  stage: &str,
+  path: impl Into<Option<&std::path::Path>>,
+  program: &str,
+  args: Vec<String>,
   terms: &[String],
   combinator: SearchCombinator,
   invert: bool,
-) -> String {
-  let maybe_invert = if invert { " -v" } else { Default::default() };
+) -> Log {
+  let grep_args = log_grep_args(terms, combinator, invert);
+  let command = format!(
+    "{} 2>&1 | {}",
+    command_string(program, &args),
+    command_string("grep", &grep_args)
+  );
+  let start_ts = komodo_timestamp();
+
+  let output = run_command_args(program, &args, path, None).await;
+  let input = format!("{}{}", output.stdout, output.stderr);
+  let grep_output = run_command_args(
+    "grep",
+    &grep_args,
+    None,
+    Some(input.as_bytes()),
+  )
+  .await;
+
+  output_into_log(stage, command, start_ts, grep_output)
+}
+
+fn log_grep_args(
+  terms: &[String],
+  combinator: SearchCombinator,
+  invert: bool,
+) -> Vec<String> {
+  let mut args = Vec::new();
+  if invert {
+    args.push("-v".to_string());
+  }
   match combinator {
     SearchCombinator::Or => {
-      format!("grep{maybe_invert} -E '{}'", terms.join("|"))
+      args.push("-E".to_string());
+      args.push(terms.join("|"));
     }
     SearchCombinator::And => {
-      format!(
-        "grep{maybe_invert} -P '^(?=.*{})'",
-        terms.join(")(?=.*")
-      )
+      args.push("-P".to_string());
+      args.push(format!("^(?=.*{})", terms.join(")(?=.*")));
     }
   }
+  args
 }
 
 // =====

--- a/lib/command/src/lib.rs
+++ b/lib/command/src/lib.rs
@@ -8,6 +8,7 @@ use komodo_client::{
   entities::{komodo_timestamp, update::Log},
   parsers::parse_multiline_command,
 };
+use tokio::io::AsyncWriteExt;
 
 mod output;
 
@@ -23,6 +24,43 @@ pub async fn run_komodo_standard_command(
   let command = command.into();
   let start_ts = komodo_timestamp();
   let output = run_standard_command(&command, path).await;
+  output_into_log(stage, command, start_ts, output)
+}
+
+/// Commands are run directly with args passed separately.
+pub async fn run_komodo_command_args(
+  stage: &str,
+  path: impl Into<Option<&Path>>,
+  program: &str,
+  args: impl IntoIterator<Item = impl AsRef<str>>,
+) -> Log {
+  let args = args
+    .into_iter()
+    .map(|arg| arg.as_ref().to_string())
+    .collect::<Vec<_>>();
+  let command = command_string(program, &args);
+  let start_ts = komodo_timestamp();
+  let output = run_command_args(program, &args, path, None).await;
+  output_into_log(stage, command, start_ts, output)
+}
+
+/// Commands are run directly with args passed separately, and stdin piped.
+pub async fn run_komodo_command_args_with_stdin(
+  stage: &str,
+  path: impl Into<Option<&Path>>,
+  program: &str,
+  args: impl IntoIterator<Item = impl AsRef<str>>,
+  stdin: impl AsRef<[u8]>,
+) -> Log {
+  let args = args
+    .into_iter()
+    .map(|arg| arg.as_ref().to_string())
+    .collect::<Vec<_>>();
+  let command = command_string(program, &args);
+  let start_ts = komodo_timestamp();
+  let output =
+    run_command_args(program, &args, path, Some(stdin.as_ref()))
+      .await;
   output_into_log(stage, command, start_ts, output)
 }
 
@@ -158,6 +196,69 @@ pub async fn run_standard_command(
   }
 
   CommandOutput::from(cmd.output().await)
+}
+
+/// Commands are run directly with args passed separately.
+pub async fn run_command_args(
+  program: &str,
+  args: &[String],
+  path: impl Into<Option<&Path>>,
+  stdin: Option<&[u8]>,
+) -> CommandOutput {
+  let mut cmd = Command::new(program);
+
+  cmd
+    .args(args)
+    .kill_on_drop(true)
+    .stdin(if stdin.is_some() {
+      Stdio::piped()
+    } else {
+      Stdio::null()
+    })
+    .stdout(Stdio::piped())
+    .stderr(Stdio::piped());
+
+  if let Some(path) = path.into() {
+    match path.canonicalize() {
+      Ok(path) => {
+        cmd.current_dir(path);
+      }
+      Err(e) => return CommandOutput::from_err(e),
+    }
+  }
+
+  let mut child = match cmd.spawn() {
+    Ok(child) => child,
+    Err(e) => return CommandOutput::from_err(e),
+  };
+
+  if let Some(stdin) = stdin {
+    match child.stdin.take() {
+      Some(mut child_stdin) => {
+        if let Err(e) = child_stdin.write_all(stdin).await {
+          return CommandOutput::from_err(e);
+        }
+      }
+      None => {
+        return CommandOutput::from_err(std::io::Error::other(
+          "Failed to open command stdin",
+        ));
+      }
+    }
+  }
+
+  CommandOutput::from(child.wait_with_output().await)
+}
+
+pub fn command_string(program: &str, args: &[String]) -> String {
+  std::iter::once(program.to_string())
+    .chain(args.iter().map(|arg| {
+      shlex::try_quote(arg)
+        .map(|arg| arg.into_owned())
+        .unwrap_or_else(|_| arg.clone())
+    }))
+    .collect::<Vec<_>>()
+    .join(" ")
 }
 
 fn shell() -> &'static str {


### PR DESCRIPTION
Ref. #1377 

Avoid interpolating registry tokens into a shell command during docker login. This preserves passwords containing shell-special characters such as quotes or dollar signs.

## Summary

  Fix Docker registry login handling in Periphery by passing the registry token directly to `docker login --password-stdin` instead of interpolating it into a shell command.

  ## Why

  Registry passwords or tokens containing shell-special characters like `'` or `$` could break login because they were evaluated by the shell before reaching Docker.

  ## Changes

  - Replace `echo {token} | docker login ...` with direct `tokio::process::Command` execution.
## Changes

  - Replace `echo {token} | docker login ...` with direct `tokio::process::Command` execution.
  - Write the registry token to the Docker process stdin.
  - Preserve existing Docker login error handling behavior.

  ## Verification

  - `cargo fmt --check`
  - `git diff --check`
  - `cargo check -p komodo_periphery`
  - VSCode `Init` task equivalent completed