### PR TITLE
feat: implement custom headers for custom alerters

### DIFF
--- a/bin/core/src/alert/mod.rs
+++ b/bin/core/src/alert/mod.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use anyhow::{Context, anyhow};
 use database::mungos::{find::find_collect, mongodb::bson::doc};
 use futures_util::future::join_all;
@@ -106,14 +108,17 @@ pub async fn send_alert_to_alerter(
   }
 
   match &alerter.config.endpoint {
-    AlerterEndpoint::Custom(CustomAlerterEndpoint { url }) => {
-      send_custom_alert(url, alert).await.with_context(|| {
+    AlerterEndpoint::Custom(CustomAlerterEndpoint {
+      url,
+      headers,
+    }) => send_custom_alert(url, headers, alert).await.with_context(
+      || {
         format!(
           "Failed to send alert to Custom Alerter {}",
           alerter.name
         )
-      })
-    }
+      },
+    ),
     AlerterEndpoint::Slack(SlackAlerterEndpoint { url }) => {
       slack::send_alert(url, alert).await.with_context(|| {
         format!(
@@ -153,33 +158,40 @@ pub async fn send_alert_to_alerter(
 
 async fn send_custom_alert(
   url: &str,
+  headers: &HashMap<String, String>,
   alert: &Alert,
 ) -> anyhow::Result<()> {
   let VariablesAndSecrets { variables, secrets } =
     get_variables_and_secrets().await?;
-  let mut url_interpolated = url.to_string();
+  send_custom_alert_inner(url, headers, alert, &variables, &secrets)
+    .await
+}
 
-  let mut interpolator =
-    Interpolator::new(Some(&variables), &secrets);
+async fn send_custom_alert_inner(
+  url: &str,
+  headers: &HashMap<String, String>,
+  alert: &Alert,
+  variables: &HashMap<String, String>,
+  secrets: &HashMap<String, String>,
+) -> anyhow::Result<()> {
+  let mut interpolator = Interpolator::new(Some(variables), secrets);
+  let (url_interpolated, headers) = interpolate_custom_request_parts(
+    url,
+    headers,
+    &mut interpolator,
+  )?;
 
-  interpolator.interpolate_string(&mut url_interpolated)?;
+  let mut request =
+    reqwest::Client::new().post(url_interpolated).json(alert);
 
-  let res = reqwest::Client::new()
-    .post(url_interpolated)
-    .json(alert)
+  for (header, value) in headers {
+    request = request.header(&header, &value);
+  }
+
+  let res = request
     .send()
     .await
-    .map_err(|e| {
-      let replacers = interpolator
-        .secret_replacers
-        .into_iter()
-        .collect::<Vec<_>>();
-      let sanitized_error =
-        svi::replace_in_string(&format!("{e:?}"), &replacers);
-      anyhow::Error::msg(format!(
-        "Error with request: {sanitized_error}"
-      ))
-    })
+    .map_err(|e| sanitize_request_error(&interpolator, &e))
     .context("failed at post request to alerter")?;
   let status = res.status();
   if !status.is_success() {
@@ -187,11 +199,57 @@ async fn send_custom_alert(
       .text()
       .await
       .context("failed to get response text on alerter response")?;
+    let text = sanitize_interpolated_text(&interpolator, &text);
     return Err(anyhow!(
       "post to alerter failed | {status} | {text}"
     ));
   }
   Ok(())
+}
+
+fn interpolate_custom_request_parts(
+  url: &str,
+  headers: &HashMap<String, String>,
+  interpolator: &mut Interpolator,
+) -> anyhow::Result<(String, Vec<(String, String)>)> {
+  let mut url_interpolated = url.to_string();
+  interpolator.interpolate_string(&mut url_interpolated)?;
+
+  let headers = headers
+    .iter()
+    .map(|(header, value)| {
+      let mut header = header.to_string();
+      let mut value = value.to_string();
+      interpolator.interpolate_string(&mut header)?;
+      interpolator.interpolate_string(&mut value)?;
+      anyhow::Ok((header, value))
+    })
+    .collect::<anyhow::Result<Vec<_>>>()?;
+  let mut headers = headers;
+  headers.sort_by(|left, right| left.0.cmp(&right.0));
+
+  Ok((url_interpolated, headers))
+}
+
+fn sanitize_request_error(
+  interpolator: &Interpolator,
+  error: &impl std::fmt::Debug,
+) -> anyhow::Error {
+  let sanitized_error =
+    sanitize_interpolated_text(interpolator, &format!("{error:?}"));
+  anyhow::Error::msg(format!("Error with request: {sanitized_error}"))
+}
+
+fn sanitize_interpolated_text(
+  interpolator: &Interpolator,
+  text: &str,
+) -> String {
+  let replacers = interpolator
+    .secret_replacers
+    .iter()
+    .cloned()
+    .collect::<Vec<_>>();
+  svi::replace_in_string(text, &replacers)
 }
 
 fn fmt_region(region: &Option<String>) -> String {
@@ -218,6 +276,105 @@ fn fmt_stack_state(state: &StackState) -> String {
     StackState::Restarting => String::from("Restarting 🔄"),
     StackState::Down => String::from("Down ⬇️"),
     _ => state.to_string(),
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn custom_alert_interpolates_headers_and_url() {
+    let mut headers = HashMap::new();
+    headers.insert(
+      String::from("authorization"),
+      String::from("Bearer [[TOKEN]]"),
+    );
+    headers
+      .insert(String::from("x-komodo-env"), String::from("[[ENV]]"));
+
+    let mut variables = HashMap::new();
+    variables.insert(String::from("ENV"), String::from("dev"));
+
+    let mut secrets = HashMap::new();
+    secrets
+      .insert(String::from("TOKEN"), String::from("super-secret"));
+
+    let mut interpolator =
+      Interpolator::new(Some(&variables), &secrets);
+    let (url, headers) = interpolate_custom_request_parts(
+      "https://example.com/[[ENV]]",
+      &headers,
+      &mut interpolator,
+    )
+    .unwrap();
+
+    assert_eq!(url, "https://example.com/dev");
+    assert_eq!(
+      headers,
+      vec![
+        (
+          String::from("authorization"),
+          String::from("Bearer super-secret"),
+        ),
+        (String::from("x-komodo-env"), String::from("dev")),
+      ]
+    );
+  }
+
+  #[test]
+  fn custom_alert_sanitizes_secret_on_request_error() {
+    let mut headers = HashMap::new();
+    headers.insert(
+      String::from("authorization"),
+      String::from("Bearer [[TOKEN]]"),
+    );
+
+    let variables = HashMap::new();
+    let secrets = HashMap::from([(
+      String::from("TOKEN"),
+      String::from("super-secret"),
+    )]);
+    let mut interpolator =
+      Interpolator::new(Some(&variables), &secrets);
+
+    interpolate_custom_request_parts(
+      "https://example.com",
+      &headers,
+      &mut interpolator,
+    )
+    .unwrap();
+
+    let err = sanitize_request_error(
+      &interpolator,
+      &"authorization: Bearer super-secret",
+    )
+    .to_string();
+
+    assert!(err.contains("Error with request:"));
+    assert!(!err.contains("super-secret"));
+  }
+
+  #[test]
+  fn custom_alert_sanitizes_secret_in_response_body() {
+    let variables = HashMap::new();
+    let secrets = HashMap::from([(
+      String::from("TOKEN"),
+      String::from("super-secret"),
+    )]);
+    let interpolator =
+      Interpolator::new(Some(&variables), &secrets);
+    let mut interpolator = interpolator;
+    let mut token = String::from("[[TOKEN]]");
+
+    interpolator.interpolate_string(&mut token).unwrap();
+
+    let sanitized = sanitize_interpolated_text(
+      &interpolator,
+      "authorization: Bearer super-secret",
+    );
+
+    assert!(!sanitized.contains("super-secret"));
   }
 }
 

--- a/client/core/rs/src/entities/alerter.rs
+++ b/client/core/rs/src/entities/alerter.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use bson::{Document, doc};
 use derive_builder::Builder;
 use derive_default_builder::DefaultBuilder;
@@ -184,12 +186,18 @@ pub struct CustomAlerterEndpoint {
   #[serde(default = "default_custom_url")]
   #[builder(default = "default_custom_url()")]
   pub url: String,
+
+  /// Additional headers to include on the request.
+  #[serde(default)]
+  #[builder(default)]
+  pub headers: HashMap<String, String>,
 }
 
 impl Default for CustomAlerterEndpoint {
   fn default() -> Self {
     Self {
       url: default_custom_url(),
+      headers: Default::default(),
     }
   }
 }

--- a/client/core/ts/src/types.ts
+++ b/client/core/ts/src/types.ts
@@ -1113,6 +1113,7 @@ export type UserConfig =
 	description: string;
 }};
 
+
 export type LinkedLoginsMap = Record<UserConfig["type"], UserConfig>;
 
 export interface UserTotpConfig {
@@ -7006,6 +7007,8 @@ export interface CreateVariable {
 export interface CustomAlerterEndpoint {
 	/** The http/s endpoint to send the POST to */
 	url: string;
+	/** Additional headers to include on the request. */
+	headers: Record<string, string>;
 }
 
 /**
@@ -11117,4 +11120,3 @@ export type WsLoginMessage =
 	key: string;
 	secret: string;
 }};
-

--- a/docsite/docs/resources.md
+++ b/docsite/docs/resources.md
@@ -70,4 +70,5 @@ All resources which depend on git repos / docker registries are able to use thes
 ## Alerter
 
 - Route alerts to various endpoints.
+- `Custom` alerters can post the raw JSON alert payload to any HTTP endpoint and include custom request headers.
 - Can configure rules on each Alerter, such as resource whitelist, blacklist, or alert type filter.

--- a/ui/public/client/types.d.ts
+++ b/ui/public/client/types.d.ts
@@ -6738,6 +6738,8 @@ export interface CreateVariable {
 export interface CustomAlerterEndpoint {
     /** The http/s endpoint to send the POST to */
     url: string;
+    /** Additional headers to include on the request. */
+    headers: Record<string, string>;
 }
 /**
  * Deletes the action at the given id, and returns the deleted action.

--- a/ui/src/lib/utils.ts
+++ b/ui/src/lib/utils.ts
@@ -30,6 +30,13 @@ export function envToText(envVars: Types.EnvironmentVar[] | undefined) {
   );
 }
 
+export function recordToText(record: Record<string, string> | undefined) {
+  return Object.entries(record ?? {})
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([key, value]) => `${key}: ${value}`)
+    .join("\n");
+}
+
 export function textToEnv(env: string): Types.EnvironmentVar[] {
   return env
     .split("\n")
@@ -39,6 +46,39 @@ export function textToEnv(env: string): Types.EnvironmentVar[] {
       return [first, rest.join("=")];
     })
     .map(([variable, value]) => ({ variable, value }));
+}
+
+export function textToRecord(text: string): Record<string, string> {
+  const record: Record<string, string> = {};
+
+  for (const rawLine of text.split("\n")) {
+    if (!keepLine(rawLine)) continue;
+
+    const line = rawLine
+      .split(" #", 1)[0]
+      .trim()
+      .replace(/^-/, "")
+      .trim();
+    const separator = line.search(/[:=]/);
+
+    if (separator === -1) {
+      throw new Error("Each header line must contain ':' or '='.");
+    }
+
+    const key = line.slice(0, separator).trim().replace(/^["']|["']$/g, "");
+    const value = line
+      .slice(separator + 1)
+      .trim()
+      .replace(/^["']|["']$/g, "");
+
+    if (!key) {
+      throw new Error("Header names cannot be empty.");
+    }
+
+    record[key] = value;
+  }
+
+  return record;
 }
 
 function keepLine(line: string) {

--- a/ui/src/resources/alerter/config/endpoint.tsx
+++ b/ui/src/resources/alerter/config/endpoint.tsx
@@ -1,7 +1,9 @@
 import { MonacoEditor } from "@/components/monaco";
+import { recordToText, textToRecord } from "@/lib/utils";
 import { ConfigInput, ConfigItem } from "@/ui/config/item";
-import { Select } from "@mantine/core";
+import { Select, Text } from "@mantine/core";
 import { Types } from "komodo_client";
+import { useEffect, useState } from "react";
 
 const ENDPOINT_TYPES: Types.AlerterEndpoint["type"][] = [
   "Custom",
@@ -15,11 +17,26 @@ export default function AlerterConfigEndpoint({
   endpoint,
   set,
   disabled,
+  onValidationChange,
 }: {
   endpoint: Types.AlerterEndpoint;
   set: (endpoint: Types.AlerterEndpoint) => void;
   disabled: boolean;
+  onValidationChange: (error: string | undefined) => void;
 }) {
+  const headersValue =
+    endpoint.type === "Custom"
+      ? recordToText(endpoint.params.headers)
+      : "";
+  const [headersText, setHeadersText] = useState(headersValue);
+  const [headersError, setHeadersError] = useState<string | undefined>();
+
+  useEffect(() => {
+    setHeadersText(headersValue);
+    setHeadersError(undefined);
+    onValidationChange(undefined);
+  }, [endpoint, headersValue, onValidationChange]);
+
   return (
     <>
       <ConfigItem
@@ -34,6 +51,7 @@ export default function AlerterConfigEndpoint({
               type: type as Types.AlerterEndpoint["type"],
               params: {
                 url: defaultUrl(type as Types.AlerterEndpoint["type"]),
+                ...(type === "Custom" ? { headers: {} } : {}),
               },
             })
           }
@@ -50,6 +68,42 @@ export default function AlerterConfigEndpoint({
           readOnly={disabled}
         />
       </ConfigItem>
+      {endpoint.type === "Custom" && (
+        <ConfigItem
+          label="Headers"
+          description="Additional request headers to include when posting the JSON alert payload. Use one `Header: value` pair per line."
+        >
+          <MonacoEditor
+            value={headersText}
+            language="key_value"
+            onValueChange={(headersText) => {
+              setHeadersText(headersText);
+              try {
+                const headers = textToRecord(headersText);
+                setHeadersError(undefined);
+                onValidationChange(undefined);
+                set({
+                  ...endpoint,
+                  params: { ...endpoint.params, headers },
+                });
+              } catch (error) {
+                const message =
+                  error instanceof Error
+                    ? error.message
+                    : "Invalid header format.";
+                setHeadersError(message);
+                onValidationChange(message);
+              }
+            }}
+            readOnly={disabled}
+          />
+          {headersError && (
+            <Text c="red" size="sm" mt="xs">
+              {headersError}
+            </Text>
+          )}
+        </ConfigItem>
+      )}
       {endpoint.type === "Ntfy" && (
         <ConfigInput
           label="Email"

--- a/ui/src/resources/alerter/config/index.tsx
+++ b/ui/src/resources/alerter/config/index.tsx
@@ -7,6 +7,7 @@ import AlerterConfigAlertTypes from "./alert-types";
 import AlerterConfigResources from "./resources";
 import ConfigMaintenanceWindows from "@/components/maintenance-windows";
 import { useFullAlerter } from "..";
+import { useState } from "react";
 
 export default function AlerterConfig({ id }: { id: string }) {
   const { canWrite } = usePermissions({ type: "Alerter", id });
@@ -14,6 +15,7 @@ export default function AlerterConfig({ id }: { id: string }) {
   const global_disabled =
     useRead("GetCoreInfo", {}).data?.ui_write_disabled ?? false;
   const { mutateAsync } = useWrite("UpdateAlerter");
+  const [endpointError, setEndpointError] = useState<string | undefined>();
   const [update, setUpdate] = useLocalStorage<Partial<Types.AlerterConfig>>({
     key: `alerter-${id}-update-v1`,
     defaultValue: {},
@@ -25,6 +27,7 @@ export default function AlerterConfig({ id }: { id: string }) {
   return (
     <Config
       disabled={disabled}
+      saveDisabled={!!endpointError}
       original={config}
       update={update}
       setUpdate={setUpdate}
@@ -49,6 +52,7 @@ export default function AlerterConfig({ id }: { id: string }) {
                   endpoint={endpoint!}
                   set={(endpoint) => set({ endpoint })}
                   disabled={disabled}
+                  onValidationChange={setEndpointError}
                 />
               ),
             },

--- a/ui/src/ui/config/confirm.tsx
+++ b/ui/src/ui/config/confirm.tsx
@@ -35,6 +35,9 @@ export default function ConfirmUpdate<T>({
   const [opened, { open, close }] = useDisclosure();
 
   const handleConfirm = async () => {
+    if (disabled) {
+      return;
+    }
     await onConfirm();
     close();
   };
@@ -47,7 +50,7 @@ export default function ConfirmUpdate<T>({
   });
 
   useCtrlKeyListener("Enter", () => {
-    if (opened || !openKeyListener) {
+    if (opened || disabled || !openKeyListener) {
       return;
     }
     open();
@@ -100,6 +103,7 @@ export default function ConfirmUpdate<T>({
               }}
               w={{ base: "100%", xs: 200 }}
               loading={loading}
+              disabled={disabled}
             >
               Save
             </Button>

--- a/ui/src/ui/config/index.tsx
+++ b/ui/src/ui/config/index.tsx
@@ -50,6 +50,7 @@ export interface ConfigProps<T> {
   update: Partial<T>;
   setUpdate: React.Dispatch<SetStateAction<Partial<T>>>;
   disabled: boolean;
+  saveDisabled?: boolean;
   onSave: () => Promise<unknown>;
   titleOther?: ReactNode;
   disableSidebar?: boolean;
@@ -65,6 +66,7 @@ export default function Config<T>({
   update,
   setUpdate,
   disabled,
+  saveDisabled,
   onSave,
   titleOther,
   disableSidebar,
@@ -175,7 +177,7 @@ export default function Config<T>({
           original={original}
           update={update}
           onConfirm={onConfirm}
-          disabled={disabled}
+          disabled={disabled || !!saveDisabled}
           fileContentsLanguage={fileContentsLanguage}
           fullWidth={fullWidth}
         />


### PR DESCRIPTION
# Summary
Adds custom request headers for Custom alerter endpoints and hardens the feature against two regressions found during review. Closes #1398 

# Changes
Added headers: Record<string, string> / HashMap<String, String> to CustomAlerterEndpoint
Updated custom alert delivery to interpolate header values the same way as the URL
Sanitized secrets in custom alerter non-2xx response bodies, not just request-send errors
Added backend tests covering:
URL + header interpolation
secret sanitization on request errors
secret sanitization in response bodies
Added UI support for editing custom headers in the alerter endpoint config
Blocked save when header text is invalid, including the confirm modal and keyboard save path

# Notes
I also ran a UI build after installing dependencies, but the workspace currently has unrelated pre-existing TypeScript/module-resolution failures, so there was no clean end-to-end frontend build signal attributable to this change alone.