### PR TITLE
fix: fall back to location.origin when VITE_KOMODO_HOST is empty string

### DIFF
--- a/ui/src/main.tsx
+++ b/ui/src/main.tsx
@@ -20,7 +20,7 @@ import "mogh_ui/index.scss";
 initMonaco();
 
 export const KOMODO_BASE_URL =
-  import.meta.env.VITE_KOMODO_HOST ?? location.origin;
+  import.meta.env.VITE_KOMODO_HOST || location.origin;
 export const UPDATE_WS_URL =
   KOMODO_BASE_URL.replace("http", "ws") + "/ws/update";
 const client = new QueryClient({


### PR DESCRIPTION
Closes #1359.

`ui/Dockerfile` defaults `ARG VITE_KOMODO_HOST=""`, so any image built without overriding the ARG bakes the empty string into the bundle. `??` only falls back on `null`/`undefined`, so `KOMODO_BASE_URL` ends up as `""`. That breaks `new WebSocket("/ws/update")` (absolute URL required) and makes auth/API requests resolve against the page origin instead of the configured backend.

Switching to `||` covers the empty-string case while preserving the existing behavior for unset and real-URL values.

Reproduced locally with `VITE_KOMODO_HOST="" yarn dev`:

```js
(await import('/src/main.tsx')).KOMODO_BASE_URL
// Before fix: ""
// After fix:  "http://localhost:5173"
```

Also verified with the env var unset — output is unchanged either way, so the dev path isn't affected.