### PR TITLE
feat: Add Infisical support to Periphery

### DIFF
--- a/bin/periphery/debian-deps.sh
+++ b/bin/periphery/debian-deps.sh
@@ -10,9 +10,7 @@ curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/doc
 chmod a+r /etc/apt/keyrings/docker.asc
 
 # Infisical setup
-curl -fsSL 'https://artifacts-cli.infisical.com/setup.deb.sh' -o setup.deb.sh
-chmod +x setup.deb.sh
-./setup.deb.sh
+curl -fsSL 'https://artifacts-cli.infisical.com/setup.deb.sh' | bash
 
 echo \
   "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/debian \

--- a/bin/periphery/debian-deps.sh
+++ b/bin/periphery/debian-deps.sh
@@ -9,6 +9,11 @@ install -m 0755 -d /etc/apt/keyrings
 curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc
 chmod a+r /etc/apt/keyrings/docker.asc
 
+# Infisical setup
+curl -fsSL 'https://artifacts-cli.infisical.com/setup.deb.sh' -o setup.deb.sh
+chmod +x setup.deb.sh
+./setup.deb.sh
+
 echo \
   "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/debian \
   $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
@@ -17,7 +22,7 @@ echo \
 apt-get update
 
 # apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
-apt-get install -y docker-ce-cli docker-buildx-plugin docker-compose-plugin
+apt-get install -y docker-ce-cli docker-buildx-plugin docker-compose-plugin infisical
 
 rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Similar to https://github.com/moghtech/komodo/pull/1053, but this is only needed inside Periphery.

This could also be a part of solving https://github.com/moghtech/komodo/issues/677

---

<details>
<summary>Example Usage:</summary>


```
compose_cmd_wrapper = """
export INFISICAL_TOKEN=$(infisical login --domain="[[INFISICAL_URL]]" --method=universal-auth --client-id="[[INFISICAL_ID]]" --client-secret="[[INFISICAL_SECRET]]" --silent --plain) && infisical run --env=prod --path=/ --domain=[[INFISICAL_URL]] --token=$INFISICAL_TOKEN --projectId=[[INFISICAL_WORKSPACE]] -- [[COMPOSE_COMMAND]]
"""
```

INFISICAL_URL=https://infisical.domain.com/api
INFISICAL_ID=xxxxxx-xx-xx-xx-xxxxxxxx (Client ID)
INFISICAL_SECRET=xxxxxxxxxxxxxxxxxxxxxxx
INFISICAL_WORKSPACE=xxxxxx-xx-xx-xx-xxxxxxxx
</details>
