### PR TITLE
Fix #387: Fix git clone auth by honoring configured git account username

### DIFF
--- a/bin/core/src/helpers/mod.rs
+++ b/bin/core/src/helpers/mod.rs
@@ -55,7 +55,14 @@ pub fn empty_or_only_spaces(word: &str) -> bool {
 
 /// First checks db for token, then checks core config.
 /// Only errors if db call errors.
-/// Returns (token, use_https)
+/// Returns the configured account credential prepared for HTTPS basic auth.
+///
+/// The returned value is formatted as `"<username>:<token>"` so that
+/// [`RepoExecutionArgs::remote_url`] produces
+/// `https://<username>:<token>@host/...`. If the stored token already
+/// contains a `:`, the user has manually combined the credentials
+/// (the v1.19.2 workaround for issue #387) and we pass it through
+/// unchanged for backwards compatibility.
 pub async fn git_token(
   provider_domain: &str,
   account_username: &str,
@@ -71,7 +78,10 @@ pub async fn git_token(
     .context("failed to query db for git provider accounts")?;
   if let Some(provider) = db_provider {
     on_https_found(provider.https);
-    return Ok(Some(provider.token));
+    return Ok(Some(combine_account_credential(
+      account_username,
+      &provider.token,
+    )));
   }
   Ok(
     core_config()
@@ -84,9 +94,30 @@ pub async fn git_token(
           .accounts
           .iter()
           .find(|account| account.username == account_username)
-          .map(|account| account.token.clone())
+          .map(|account| {
+            combine_account_credential(account_username, &account.token)
+          })
       }),
   )
+}
+
+/// Combine a configured git account `username` with its `token` into the
+/// `"<username>:<token>"` form that [`RepoExecutionArgs::remote_url`]
+/// splits back out for HTTPS basic auth.
+///
+/// Without this, [`RepoExecutionArgs::remote_url`] would fall back to its
+/// hardcoded `token:<token>@` default and clones against providers that
+/// validate the basic-auth username (GitLab deploy tokens, Bitbucket,
+/// fine-grained GitHub PATs) would fail with `HTTP Basic: Access denied`.
+///
+/// If the stored token already contains a `:` the user has manually
+/// combined the credentials (the v1.19.2 workaround for issue #387);
+/// return it unchanged so existing setups keep working.
+fn combine_account_credential(username: &str, token: &str) -> String {
+  if token.contains(':') {
+    return token.to_string();
+  }
+  format!("{username}:{token}")
 }
 
 pub async fn stack_git_token(

--- a/bin/periphery/src/helpers.rs
+++ b/bin/periphery/src/helpers.rs
@@ -238,6 +238,13 @@ pub async fn handle_post_repo_execution(
 //  Token
 // =======
 
+/// Look up a raw access token in the Periphery git provider config.
+///
+/// Use this when you only need the secret (for example to redact it from
+/// log output). For building a clone URL prefer [`git_token`], which also
+/// combines the configured username with the token so the resulting URL
+/// authenticates correctly against providers that validate the basic-auth
+/// username (GitLab deploy tokens, Bitbucket, fine-grained GitHub PATs).
 pub fn git_token_simple(
   domain: &str,
   account_username: &str,
@@ -252,6 +259,19 @@ pub fn git_token_simple(
     .with_context(|| format!("Did not find token in config for git account {account_username} | domain {domain}"))
 }
 
+/// Resolve the credential to use when running `git clone` / `git fetch`
+/// on the Periphery host.
+///
+/// If Core sent a token for this execution, use it as-is — Core is
+/// responsible for formatting it as `"<username>:<token>"` (see
+/// `git_token` in the Core helpers). Otherwise fall back to the
+/// Periphery config and combine the configured account username with
+/// its token in the same form so [`RepoExecutionArgs::remote_url`]
+/// produces `https://<username>:<token>@host/...`.
+///
+/// Backwards-compatible: if the stored token already contains a `:`
+/// the caller used the v1.19.2 workaround for issue #387, so we pass
+/// it through unchanged.
 pub fn git_token(
   core_token: Option<String>,
   args: &RepoExecutionArgs,
@@ -263,7 +283,10 @@ pub fn git_token(
     return Ok(None);
   };
   let token = git_token_simple(&args.provider, account)?;
-  Ok(Some(token.to_string()))
+  if token.contains(':') {
+    return Ok(Some(token.to_string()));
+  }
+  Ok(Some(format!("{account}:{token}")))
 }
 
 pub fn registry_token(


### PR DESCRIPTION
[Closes #387](https://github.com/moghtech/komodo/issues/387)

## Why
Private repo clones can fail on providers that validate HTTP basic-auth usernames (for example GitLab deploy tokens, Bitbucket, and GitHub fine-grained PATs).
Komodo currently resolves a token but loses the configured account username before URL construction, so clone URLs fall back to `token:<token>@...`. That causes `HTTP Basic: Access denied` for providers that require a specific username.
## What changed
- Updated Core git credential resolution to return credentials in `username:token` form (while preserving existing `token` values that already contain `:` for backward compatibility).
- Updated Periphery fallback credential resolution to do the same when Core does not provide a token.
- Added comments documenting the auth flow and compatibility behavior.
## Behavior
Before:
- Clone URL often became `https://token:<token>@<provider>/<repo>`
After:
- Clone URL uses configured account username:
  - `https://<configured-username>:<token>@<provider>/<repo>`
## Backward compatibility
- Existing setups that already use the v1.19.2 workaround (`token` field manually set to `username:token`) continue to work unchanged.
## Validation
- `cargo check -p komodo_core` passes
- `cargo check -p komodo_periphery` passes
- `cargo clippy -p komodo_core -p komodo_periphery --no-deps` passes
- Reproduced failing GitLab deploy-token clone case before patch
- NEEDS TO BE DONE - Verify clone succeeds after patch with same provider/account config 