### PR TITLE
Send keepalive pings on user websockets to survive idle proxy timeouts

### DIFF
--- a/bin/core/src/api/ws/mod.rs
+++ b/bin/core/src/api/ws/mod.rs
@@ -24,6 +24,9 @@ use crate::{
 mod terminal;
 mod update;
 
+pub(super) const WS_KEEP_ALIVE_INTERVAL: std::time::Duration =
+  std::time::Duration::from_secs(30);
+
 pub fn router() -> Router {
   Router::new()
     // Periphery facing

--- a/bin/core/src/api/ws/terminal.rs
+++ b/bin/core/src/api/ws/terminal.rs
@@ -117,9 +117,25 @@ async fn forward_ws_channel(
   };
 
   let periphery_to_core = async {
+    let mut keep_alive =
+      tokio::time::interval(super::WS_KEEP_ALIVE_INTERVAL);
     loop {
       // Already adheres to cancellation token
-      match periphery_receiver.recv().await {
+      let recv = tokio::select! {
+        // Websocket keep-alive ping
+        _ = keep_alive.tick() => {
+          if client_send
+            .send(ws::Message::Ping(Bytes::new()))
+            .await
+            .is_err()
+          {
+            break;
+          }
+          continue;
+        }
+        recv = periphery_receiver.recv() => recv,
+      };
+      match recv {
         Ok(Ok(bytes)) => {
           if let Err(e) =
             client_send.send(ws::Message::Binary(bytes.into())).await

--- a/bin/core/src/api/ws/update.rs
+++ b/bin/core/src/api/ws/update.rs
@@ -3,6 +3,7 @@ use axum::{
   extract::{WebSocketUpgrade, ws::Message},
   response::IntoResponse,
 };
+use bytes::Bytes;
 use futures_util::{SinkExt, StreamExt};
 use komodo_client::entities::{
   ResourceTarget, permission::PermissionLevel, user::User,
@@ -38,10 +39,19 @@ pub async fn handler(
     let cancel_clone = cancel.clone();
 
     tokio::spawn(async move {
+      let mut keep_alive =
+        tokio::time::interval(super::WS_KEEP_ALIVE_INTERVAL);
       loop {
-        // poll for updates off the receiver / await cancel.
+        // poll for updates off the receiver / await cancel / send keep-alive ping.
         let update = select! {
           _ = cancel_clone.cancelled() => break,
+          _ = keep_alive.tick() => {
+            if ws_sender.send(Message::Ping(Bytes::new())).await.is_err() {
+              cancel_clone.cancel();
+              break;
+            }
+            continue;
+          }
           update = receiver.recv() => {update.expect("failed to recv update msg")}
         };
 


### PR DESCRIPTION
Cloudflare closes TCP sockets that go quiet, and our two user-facing sockets `/ws/update` and `/ws/terminal`, send nothing while idle. The socket sits there until the proxy reaps it and the UI falls back to its reconnect loop. 

This PR makes the server send a WebSocket Ping every 30s on both endpoints. 

(Core<->Periphery connections already ping every 5s. This only touches the two browser-facing endpoints.)

## Files
  - `bin/core/src/api/ws/mod.rs` - shared `WS_KEEP_ALIVE_INTERVAL` (30s)
  - `bin/core/src/api/ws/update.rs` - ping in the update send loop
  - `bin/core/src/api/ws/terminal.rs` - ping in the terminal forward loop