### PR TITLE
feat(procedure): per-stage concurrency cap (max_concurrent) + wait_for_completion for batch deploys

### DIFF
--- a/bin/core/src/api/execute/build.rs
+++ b/bin/core/src/api/execute/build.rs
@@ -622,6 +622,7 @@ async fn handle_post_build_redeploy(build_id: &str) {
             deployment: deployment.id.clone(),
             stop_signal: None,
             stop_time: None,
+            wait_for_completion: false,
           });
           let user = auto_redeploy_user().to_owned();
           let res = async {
@@ -630,6 +631,7 @@ async fn handle_post_build_redeploy(build_id: &str) {
               deployment: deployment.id.clone(),
               stop_signal: None,
               stop_time: None,
+              wait_for_completion: false,
             }
             .resolve(&ExecuteArgs {
               user,

--- a/bin/core/src/api/execute/deployment.rs
+++ b/bin/core/src/api/execute/deployment.rs
@@ -1,4 +1,5 @@
 use std::sync::OnceLock;
+use std::time::{Duration, Instant};
 
 use anyhow::{Context, anyhow};
 use formatting::format_serror;
@@ -46,6 +47,7 @@ impl super::BatchExecute for BatchDeploy {
       deployment,
       stop_signal: None,
       stop_time: None,
+      wait_for_completion: false,
     })
   }
 }
@@ -211,6 +213,9 @@ impl Resolve<ExecuteArgs> for Deploy {
     update_update(update.clone()).await?;
 
     let deployment_id = deployment.id.clone();
+    // Captured before `deployment` is moved into the deploy request below, so we
+    // can poll the container by name if `wait_for_completion` is set.
+    let container_name = deployment.name.clone();
 
     match swarm_or_server {
       SwarmOrServer::None => unreachable!(),
@@ -251,7 +256,15 @@ impl Resolve<ExecuteArgs> for Deploy {
         {
           Ok(log) => {
             refresh_server_cache(&server, true).await;
-            update.logs.push(log)
+            update.logs.push(log);
+            if self.wait_for_completion {
+              wait_for_container_exit(
+                &server,
+                &container_name,
+                &mut update,
+              )
+              .await;
+            }
           }
           Err(e) => {
             update.push_error_log(
@@ -281,6 +294,62 @@ impl Resolve<ExecuteArgs> for Deploy {
     update_update(update.clone()).await?;
 
     Ok(update)
+  }
+}
+
+/// Poll a container's state until it exits (or is gone), so a `Deploy` with
+/// `wait_for_completion` only resolves once a one-shot / batch container has
+/// actually finished. A generous hard cap prevents a hung container from
+/// holding the caller (e.g. a `max_concurrent` worker-pool slot) forever.
+async fn wait_for_container_exit(
+  server: &Server,
+  container_name: &str,
+  update: &mut Update,
+) {
+  use komodo_client::entities::docker::container::ContainerStateStatusEnum as CState;
+  const POLL_SECS: u64 = 5;
+  const MAX_WAIT_SECS: u64 = 86_400; // 24h safety cap
+
+  update.push_simple_log(
+    "Wait For Completion",
+    format!("Waiting for container '{container_name}' to exit..."),
+  );
+  let deadline = Instant::now() + Duration::from_secs(MAX_WAIT_SECS);
+  loop {
+    tokio::time::sleep(Duration::from_secs(POLL_SECS)).await;
+    let finished = match periphery_client(server).await {
+      Ok(client) => match client
+        .request(api::container::InspectContainer {
+          name: container_name.to_string(),
+        })
+        .await
+      {
+        Ok(container) => matches!(
+          container.state.map(|state| state.status),
+          Some(CState::Exited) | Some(CState::Dead) | None
+        ),
+        // Inspect failed (likely the container was removed) -> treat as done.
+        Err(_) => true,
+      },
+      // Couldn't reach periphery -> stop waiting rather than hang forever.
+      Err(_) => true,
+    };
+    if finished {
+      update.push_simple_log(
+        "Wait For Completion",
+        format!("Container '{container_name}' finished"),
+      );
+      return;
+    }
+    if Instant::now() >= deadline {
+      update.push_error_log(
+        "Wait For Completion",
+        format!(
+          "Timed out after {MAX_WAIT_SECS}s waiting for container '{container_name}' to exit"
+        ),
+      );
+      return;
+    }
   }
 }
 

--- a/bin/core/src/api/write/deployment.rs
+++ b/bin/core/src/api/write/deployment.rs
@@ -515,6 +515,7 @@ pub async fn check_deployment_for_update_inner(
           deployment: name.clone(),
           stop_signal: None,
           stop_time: None,
+          wait_for_completion: false,
         }),
         auto_redeploy_user().to_owned(),
       )

--- a/bin/core/src/helpers/procedure.rs
+++ b/bin/core/src/helpers/procedure.rs
@@ -3,7 +3,7 @@ use std::time::{Duration, Instant};
 use anyhow::{Context, anyhow};
 use database::mungos::by_id::find_one_by_id;
 use formatting::{Color, bold, colored, format_serror, muted};
-use futures_util::future::join_all;
+use futures_util::stream::{self, StreamExt};
 use komodo_client::{
   api::execute::*,
   entities::{
@@ -58,6 +58,7 @@ pub async fn execute_procedure(
         .filter(|item| item.enabled)
         .map(|item| item.execution.clone())
         .collect(),
+      stage.max_concurrent,
       &procedure.id,
       &procedure.name,
       update,
@@ -89,6 +90,8 @@ pub async fn execute_procedure(
 #[instrument("ExecuteProcedureStage", skip_all)]
 async fn execute_procedure_stage(
   _executions: Vec<Execution>,
+  // Max executions to run in parallel. `0` = no limit (all at once).
+  max_concurrent: i64,
   parent_id: &str,
   parent_name: &str,
   update: &Mutex<Update>,
@@ -210,7 +213,21 @@ async fn execute_procedure_stage(
     .await;
     res
   });
-  join_all(futures)
+  // Run the stage's executions concurrently. With `max_concurrent = 0` (the
+  // default), this runs them all at once — identical to the original
+  // `join_all`. With `max_concurrent = n > 0`, it acts as a worker pool of
+  // size `n`: only `n` executions run at a time, the rest are queued and
+  // started as running ones finish, so a stage that fans out to many
+  // executions can't saturate the host. All executions still complete before
+  // the stage returns, and the first error is propagated.
+  let limit = if max_concurrent > 0 {
+    max_concurrent as usize
+  } else {
+    usize::MAX
+  };
+  stream::iter(futures)
+    .buffer_unordered(limit)
+    .collect::<Vec<_>>()
     .await
     .into_iter()
     .collect::<anyhow::Result<Vec<_>>>()?;

--- a/bin/core/src/helpers/procedure.rs
+++ b/bin/core/src/helpers/procedure.rs
@@ -621,6 +621,7 @@ impl ExtendBatch for BatchDeploy {
       deployment,
       stop_signal: None,
       stop_time: None,
+      wait_for_completion: false,
     })
   }
 }

--- a/bin/core/src/startup.rs
+++ b/bin/core/src/startup.rs
@@ -384,7 +384,8 @@ async fn ensure_init_user_and_resources() {
             execution: Execution::BackupCoreDatabase(BackupCoreDatabase {}),
             enabled: true
           }
-        ]
+        ],
+        max_concurrent: 0,
       }])
       .schedule(String::from("Every day at 01:00"))
       .build()
@@ -427,7 +428,8 @@ async fn ensure_init_user_and_resources() {
             execution: Execution::GlobalAutoUpdate(GlobalAutoUpdate { skip_auto_update: false }),
             enabled: true
           }
-        ]
+        ],
+        max_concurrent: 0,
       }])
       .schedule(String::from("Every day at 03:00"))
       .build()
@@ -479,7 +481,8 @@ async fn ensure_init_user_and_resources() {
             execution: Execution::RotateAllServerKeys(RotateAllServerKeys {}),
             enabled: true
           }
-        ]
+        ],
+        max_concurrent: 0,
       }])
       .schedule(String::from("Every day at 06:00"))
       .build()

--- a/bin/core/src/sync/deploy.rs
+++ b/bin/core/src/sync/deploy.rs
@@ -94,6 +94,7 @@ pub async fn deploy_from_cache(
                 deployment: name.to_string(),
                 stop_signal: None,
                 stop_time: None,
+                wait_for_completion: false,
               });
 
               let update = init_execution_update(&req, user).await?;

--- a/client/core/rs/src/api/execute/deployment.rs
+++ b/client/core/rs/src/api/execute/deployment.rs
@@ -47,6 +47,18 @@ pub struct Deploy {
   /// Override the default termination max time.
   /// Only used when deployment needs to be taken down before redeploy.
   pub stop_time: Option<i32>,
+  /// If `true`, after the container is started, wait until it **exits** before
+  /// this execution resolves (by polling the container state). Default `false`:
+  /// resolve as soon as the container is started (correct for long-running
+  /// services).
+  ///
+  /// Set this for one-shot / batch deployments so that a procedure stage with
+  /// `max_concurrent` actually caps how many run *at the same time* — the
+  /// worker-pool slot stays held until the container finishes, instead of
+  /// freeing as soon as the (fire-and-forget) deploy is issued. Ignored for
+  /// Swarm services.
+  #[serde(default)]
+  pub wait_for_completion: bool,
 }
 
 //

--- a/client/core/rs/src/entities/procedure.rs
+++ b/client/core/rs/src/entities/procedure.rs
@@ -211,7 +211,8 @@ impl utoipa::PartialSchema for PartialProcedureConfig {
 #[cfg(feature = "utoipa")]
 impl utoipa::ToSchema for PartialProcedureConfig {}
 
-/// A single stage of a procedure. Runs a list of executions in parallel.
+/// A single stage of a procedure. Runs a list of executions in parallel,
+/// optionally capped to `max_concurrent` at a time.
 #[typeshare]
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
@@ -225,6 +226,15 @@ pub struct ProcedureStage {
   /// The executions in the stage
   #[serde(default, alias = "execution")]
   pub executions: Vec<EnabledExecution>,
+  /// Maximum number of executions to run in parallel within this stage.
+  ///
+  /// `0` (the default) means no limit: every execution runs at once, the
+  /// original behavior. Set e.g. `10` to run the stage as a worker pool of
+  /// that size — the executions beyond the limit are queued and started as
+  /// running ones finish. Useful to avoid saturating the host (CPU / RAM /
+  /// network / disk) when a stage fans out to many executions.
+  #[serde(default)]
+  pub max_concurrent: I64,
 }
 
 /// Allows to enable / disabled procedures in the sequence / parallel vec on the fly

--- a/client/core/ts/src/types.ts
+++ b/client/core/ts/src/types.ts
@@ -7280,6 +7280,19 @@ export interface Deploy {
 	 * Only used when deployment needs to be taken down before redeploy.
 	 */
 	stop_time?: number;
+	/**
+	 * If `true`, after the container is started, wait until it **exits** before
+	 * this execution resolves (by polling the container state). Default `false`:
+	 * resolve as soon as the container is started (correct for long-running
+	 * services).
+	 * 
+	 * Set this for one-shot / batch deployments so that a procedure stage with
+	 * `max_concurrent` actually caps how many run *at the same time* — the
+	 * worker-pool slot stays held until the container finishes, instead of
+	 * freeing as soon as the (fire-and-forget) deploy is issued. Ignored for
+	 * Swarm services.
+	 */
+	wait_for_completion?: boolean;
 }
 
 /** Deploys the target stack. `docker compose up`. Response: [Update] */

--- a/client/core/ts/src/types.ts
+++ b/client/core/ts/src/types.ts
@@ -953,7 +953,10 @@ export interface EnabledExecution {
 	enabled: boolean;
 }
 
-/** A single stage of a procedure. Runs a list of executions in parallel. */
+/**
+ * A single stage of a procedure. Runs a list of executions in parallel,
+ * optionally capped to `max_concurrent` at a time.
+ */
 export interface ProcedureStage {
 	/** A name for the procedure */
 	name: string;
@@ -961,6 +964,16 @@ export interface ProcedureStage {
 	enabled: boolean;
 	/** The executions in the stage */
 	executions?: EnabledExecution[];
+	/**
+	 * Maximum number of executions to run in parallel within this stage.
+	 * 
+	 * `0` (the default) means no limit: every execution runs at once, the
+	 * original behavior. Set e.g. `10` to run the stage as a worker pool of
+	 * that size — the executions beyond the limit are queued and started as
+	 * running ones finish. Useful to avoid saturating the host (CPU / RAM /
+	 * network / disk) when a stage fans out to many executions.
+	 */
+	max_concurrent?: I64;
 }
 
 /** Config for the [Procedure] */

--- a/docsite/docs/automate/procedures.md
+++ b/docsite/docs/automate/procedures.md
@@ -8,6 +8,21 @@ A Procedure composes multiple executions (like `RunBuild`, `DeployStack`, `Deplo
 
 A stage can optionally cap how many of its executions run at once with `max_concurrent`. With the default `0` every execution runs in parallel (original behavior); set e.g. `max_concurrent = 10` to run the stage as a **worker pool** of that size — useful when a stage fans out to many executions (e.g. a `Batch*` deploy across hundreds of resources) and you don't want to saturate the host.
 
+:::note Capping one-shot / batch jobs
+`max_concurrent` limits how many executions run concurrently. Most executions block until their work is done, so the cap directly limits concurrent work. But a `Deploy` is fire-and-forget — it resolves as soon as the container is *started*, not when it *exits*. So for one-shot / batch containers (a parser, a backup job, etc.), pair `max_concurrent` with **`wait_for_completion = true`** on the `Deploy` execution: the worker-pool slot is then held until the container actually exits, so `max_concurrent = 10` means at most 10 are *running* at once.
+
+```toml
+[[procedure.config.stage]]
+name = "run-all-jobs"
+max_concurrent = 10
+executions = [
+  { execution.type = "Deploy", execution.params.deployment = "job-01", execution.params.wait_for_completion = true },
+  { execution.type = "Deploy", execution.params.deployment = "job-02", execution.params.wait_for_completion = true },
+  # ...
+]
+```
+:::
+
 ```toml
 [[procedure]]
 name = "build-and-deploy"

--- a/docsite/docs/automate/procedures.md
+++ b/docsite/docs/automate/procedures.md
@@ -6,6 +6,8 @@ Komodo offers `Procedure` and `Action` resources for orchestrating multi-resourc
 
 A Procedure composes multiple executions (like `RunBuild`, `DeployStack`, `Deploy`) into a series of **Stages**. Executions within a stage run **in parallel**; stages run **sequentially**. The Procedure waits for all executions in a stage to complete before moving to the next.
 
+A stage can optionally cap how many of its executions run at once with `max_concurrent`. With the default `0` every execution runs in parallel (original behavior); set e.g. `max_concurrent = 10` to run the stage as a **worker pool** of that size — useful when a stage fans out to many executions (e.g. a `Batch*` deploy across hundreds of resources) and you don't want to saturate the host.
+
 ```toml
 [[procedure]]
 name = "build-and-deploy"
@@ -19,6 +21,7 @@ executions = [
 
 [[procedure.config.stage]]
 name = "Deploy"
+max_concurrent = 10   # run at most 10 of these deploys at a time (0 = no limit)
 executions = [
   { execution.type = "Deploy", execution.params.deployment = "my-app-01" },
   { execution.type = "Deploy", execution.params.deployment = "my-app-02" },
@@ -32,6 +35,7 @@ executions = [
 | `config.stage[].name` | Display name for the stage. | — |
 | `config.stage[].enabled` | Whether the stage is active. | `true` |
 | `config.stage[].executions` | List of executions to run in parallel within the stage. | `[]` |
+| `config.stage[].max_concurrent` | Max executions to run in parallel in the stage (`0` = no limit). | `0` |
 | `schedule` | Schedule expression. See [Schedules](schedules). | `""` |
 | `schedule_format` | `English` or `Cron`. | `English` |
 | `schedule_enabled` | Whether the schedule is active. | `true` |

--- a/ui/public/client/types.d.ts
+++ b/ui/public/client/types.d.ts
@@ -1109,7 +1109,10 @@ export interface EnabledExecution {
     /** Whether the execution is enabled to run in the procedure. */
     enabled: boolean;
 }
-/** A single stage of a procedure. Runs a list of executions in parallel. */
+/**
+ * A single stage of a procedure. Runs a list of executions in parallel,
+ * optionally capped to `max_concurrent` at a time.
+ */
 export interface ProcedureStage {
     /** A name for the procedure */
     name: string;
@@ -1117,6 +1120,11 @@ export interface ProcedureStage {
     enabled: boolean;
     /** The executions in the stage */
     executions?: EnabledExecution[];
+    /**
+     * Maximum number of executions to run in parallel within this stage.
+     * `0` (default) = no limit. Set e.g. `10` to cap concurrency (worker pool).
+     */
+    max_concurrent?: I64;
 }
 /** Config for the [Procedure] */
 export interface ProcedureConfig {

--- a/ui/public/client/types.d.ts
+++ b/ui/public/client/types.d.ts
@@ -6982,6 +6982,12 @@ export interface Deploy {
      * Only used when deployment needs to be taken down before redeploy.
      */
     stop_time?: number;
+    /**
+     * If `true`, after the container is started, wait until it exits before this
+     * execution resolves. Default `false`. Pair with a stage's `max_concurrent`
+     * to cap how many one-shot / batch deployments run at the same time.
+     */
+    wait_for_completion?: boolean;
 }
 /** Deploys the target stack. `docker compose up`. Response: [Update] */
 export interface DeployStack {

--- a/ui/src/resources/procedure/config/executions.tsx
+++ b/ui/src/resources/procedure/config/executions.tsx
@@ -181,12 +181,26 @@ export const PROCEDURE_EXECUTIONS: ProcedureExecutions = {
     params: { deployment: "" },
     Component: ({ params, setParams, disabled }) => {
       return (
-        <ResourceSelector
-          type="Deployment"
-          selected={params.deployment}
-          onSelect={(deployment) => setParams({ deployment })}
-          disabled={disabled}
-        />
+        <Stack gap="xs">
+          <ResourceSelector
+            type="Deployment"
+            selected={params.deployment}
+            onSelect={(deployment) => setParams({ ...params, deployment })}
+            disabled={disabled}
+          />
+          <Switch
+            label="Wait for completion"
+            description="Hold the slot until the container exits (one-shot / batch jobs)"
+            checked={!!params.wait_for_completion}
+            onChange={(e) =>
+              setParams({
+                ...params,
+                wait_for_completion: e.currentTarget.checked,
+              })
+            }
+            disabled={disabled}
+          />
+        </Stack>
       );
     },
   },

--- a/ui/src/resources/procedure/config/index.tsx
+++ b/ui/src/resources/procedure/config/index.tsx
@@ -20,11 +20,12 @@ import { useFullProcedure } from "..";
 
 const PROCEDURE_GIT_PROVIDER = "Procedure";
 
-export function newStage(next_index: number) {
+export function newStage(next_index: number): Types.ProcedureStage {
   return {
     name: `Stage ${next_index}`,
     enabled: true,
     executions: [defaultEnabledExecution()],
+    max_concurrent: 0,
   };
 }
 

--- a/ui/src/resources/procedure/config/stage.tsx
+++ b/ui/src/resources/procedure/config/stage.tsx
@@ -4,6 +4,7 @@ import {
   Button,
   Group,
   Menu,
+  NumberInput,
   Stack,
   Switch,
   TextInput,
@@ -44,6 +45,17 @@ export default function ProcedureStage({
           value={stage.name}
           onChange={(e) => setStage({ ...stage, name: e.target.value })}
           w={250}
+        />
+        <NumberInput
+          placeholder="Max parallel"
+          title="Max executions to run in parallel in this stage. 0 = no limit."
+          value={stage.max_concurrent || 0}
+          onChange={(v) =>
+            setStage({ ...stage, max_concurrent: Number(v) || 0 })
+          }
+          min={0}
+          w={130}
+          disabled={disabled}
         />
         <Group>
           <EnableSwitch


### PR DESCRIPTION
## Problem

Procedure stages run all their executions in parallel (`join_all`) with no limit, so a stage that fans out to many executions — a `Batch*` deploy across hundreds of resources, or a "run everything" procedure — launches them all at once and can saturate the host (CPU / RAM / network). There is no way to throttle this.

Two changes together give procedures a proper **worker-pool / task-queue** behavior.

## 1. `max_concurrent` per stage

Optional field on `ProcedureStage`:

- `0` (default) → unchanged: every execution runs at once (fully backwards compatible).
- `n > 0` → the stage runs as a worker pool of size `n`: only `n` executions run at a time, the rest are queued and started as running ones finish.

Implementation swaps `join_all(futures)` for `stream::iter(futures).buffer_unordered(limit)`. All executions still complete before the stage returns and the first error is still propagated.

## 2. `wait_for_completion` on `Deploy`

`max_concurrent` caps concurrent *executions*. Most executions block until done, but a `Deploy` is fire-and-forget — it resolves as soon as the container is *started*, not when it *exits*. So for one-shot / batch containers the cap would throttle deploy issuance but not how many actually run.

`wait_for_completion: bool` (default false) makes the `Deploy` execution poll the container (`InspectContainer`) until it exits (24h safety cap) before resolving. Combined with `max_concurrent`, a stage of `Deploy { wait_for_completion = true }` becomes a real worker pool: `max_concurrent = 10` ⇒ at most 10 containers running at once.

```toml
[[procedure.config.stage]]
name = "run-all-jobs"
max_concurrent = 10
executions = [
  { execution.type = "Deploy", execution.params.deployment = "job-01", execution.params.wait_for_completion = true },
  # ...
]
```

## Notes

- Both fields are opt-in and backwards compatible (serde defaults `0` / `false`).
- `wait_for_completion` targets Server deployments; ignored for Swarm services.
- Configurable via TOML and the procedure UI (stage "Max parallel" input + Deploy "Wait for completion" switch).
- TS types regenerated via typeshare; docs updated.

## Validation

`cargo build`, `cargo test`, and `cargo fmt --all -- --check` all pass.
