### PR TITLE
feat: add support for syncing OIDC claims with user groups

### DIFF
--- a/bin/core/src/auth/mod.rs
+++ b/bin/core/src/auth/mod.rs
@@ -1,4 +1,7 @@
-use std::sync::{Arc, LazyLock};
+use std::{
+  collections::BTreeSet,
+  sync::{Arc, LazyLock},
+};
 
 use anyhow::{Context as _, anyhow};
 use async_timing_util::{
@@ -6,11 +9,15 @@ use async_timing_util::{
 };
 use database::{
   bson::{Document, doc, to_bson},
-  mungos::by_id::update_one_by_id,
+  mungos::{
+    by_id::update_one_by_id, find::find_collect,
+    mongodb::options::UpdateOptions,
+  },
 };
 use komodo_client::entities::{
   komodo_timestamp, optional_str,
   user::{NewUserParams, User, UserConfig, UserConfigVariant},
+  user_group::UserGroup,
 };
 use mogh_auth_client::{
   api::login::LoginProvider,
@@ -18,7 +25,7 @@ use mogh_auth_client::{
   passkey::Passkey,
 };
 use mogh_auth_server::{
-  AuthImpl,
+  AuthImpl, OidcClaims,
   provider::{
     jwt::JwtProvider, oidc::SubjectIdentifier,
     passkey::PasskeyProvider,
@@ -29,6 +36,7 @@ use mogh_auth_server::{
 use mogh_error::{AddStatusCode, AddStatusCodeError, StatusCode};
 use mogh_pki::RotatableKeyPair;
 use mogh_rate_limit::RateLimiter;
+use serde_json::{Map, Value};
 
 use crate::{
   config::{core_config, core_keys},
@@ -451,6 +459,19 @@ impl AuthImpl for KomodoAuthImpl {
     })
   }
 
+  fn on_oidc_login(
+    &self,
+    user_id: String,
+    claims: OidcClaims,
+  ) -> mogh_auth_server::DynFuture<mogh_error::Result<()>> {
+    Box::pin(async move {
+      sync_oidc_user_groups(user_id, claims)
+        .await
+        .status_code(StatusCode::INTERNAL_SERVER_ERROR)?;
+      Ok(())
+    })
+  }
+
   // ===============
   // = GITHUB AUTH =
   // ===============
@@ -825,4 +846,162 @@ impl AuthImpl for KomodoAuthImpl {
   fn server_private_key(&self) -> Option<&RotatableKeyPair> {
     Some(core_keys())
   }
+}
+
+async fn sync_oidc_user_groups(
+  user_id: String,
+  claims: OidcClaims,
+) -> anyhow::Result<()> {
+  let config = core_config();
+  if !config.oidc_sync_user_groups {
+    return Ok(());
+  }
+
+  let claimed = extract_oidc_group_names(
+    &claims,
+    &config.oidc_sync_user_groups_claim,
+  );
+
+  let db = db_client();
+  let user = get_user(&user_id).await?;
+  let previous =
+    user.oidc_synced_groups.into_iter().collect::<BTreeSet<_>>();
+
+  if config.oidc_sync_user_groups_auto_create {
+    ensure_oidc_user_groups_exist(&claimed).await?;
+  }
+
+  let synced = existing_user_group_names(&claimed).await?;
+
+  if !synced.is_empty() {
+    db.user_groups
+      .update_many(
+        doc! { "name": { "$in": synced.iter().collect::<Vec<_>>() } },
+        doc! {
+          "$addToSet": { "users": &user_id },
+          "$set": { "updated_at": komodo_timestamp() },
+        },
+      )
+      .await
+      .context("failed to add user to OIDC synced user groups")?;
+  }
+
+  let stale = previous.difference(&synced).collect::<Vec<_>>();
+  if !stale.is_empty() {
+    db.user_groups
+      .update_many(
+        doc! {
+          "name": { "$in": stale },
+          "users": &user_id,
+        },
+        doc! {
+          "$pull": { "users": &user_id },
+          "$set": { "updated_at": komodo_timestamp() },
+        },
+      )
+      .await
+      .context(
+        "failed to remove user from stale OIDC synced user groups",
+      )?;
+  }
+
+  let synced = synced.into_iter().collect::<Vec<_>>();
+  update_one_by_id(
+    &db.users,
+    &user_id,
+    doc! {
+      "$set": {
+        "oidc_synced_groups": synced,
+        "updated_at": komodo_timestamp(),
+      }
+    },
+    None,
+  )
+  .await
+  .context("failed to set user OIDC synced groups")?;
+
+  Ok(())
+}
+
+async fn ensure_oidc_user_groups_exist(
+  group_names: &BTreeSet<String>,
+) -> anyhow::Result<()> {
+  let db = db_client();
+  for name in group_names {
+    db.user_groups
+      .update_one(
+        doc! { "name": name },
+        doc! {
+          "$setOnInsert": {
+            "name": name,
+            "everyone": false,
+            "users": Vec::<String>::new(),
+            "all": Document::new(),
+            "updated_at": komodo_timestamp(),
+          }
+        },
+      )
+      .with_options(UpdateOptions::builder().upsert(true).build())
+      .await
+      .with_context(|| {
+        format!("failed to ensure OIDC synced user group {name:?}")
+      })?;
+  }
+  Ok(())
+}
+
+async fn existing_user_group_names(
+  group_names: &BTreeSet<String>,
+) -> anyhow::Result<BTreeSet<String>> {
+  if group_names.is_empty() {
+    return Ok(BTreeSet::new());
+  }
+
+  let groups: Vec<UserGroup> = find_collect(
+    &db_client().user_groups,
+    doc! { "name": { "$in": group_names.iter().collect::<Vec<_>>() } },
+    None,
+  )
+  .await
+  .context("failed to query OIDC synced user groups")?;
+
+  Ok(groups.into_iter().map(|group| group.name).collect())
+}
+
+fn extract_oidc_group_names(
+  claims: &OidcClaims,
+  claim_name: &str,
+) -> BTreeSet<String> {
+  let claim = claims
+    .claim(claim_name)
+    .or_else(|| claim_at_path(&claims.claims, claim_name));
+
+  match claim {
+    Some(Value::Array(groups)) => groups
+      .iter()
+      .filter_map(Value::as_str)
+      .map(str::trim)
+      .filter(|group| !group.is_empty())
+      .map(ToString::to_string)
+      .collect(),
+    Some(Value::String(group)) => group
+      .split(',')
+      .map(str::trim)
+      .filter(|group| !group.is_empty())
+      .map(ToString::to_string)
+      .collect(),
+    _ => BTreeSet::new(),
+  }
+}
+
+fn claim_at_path<'a>(
+  claims: &'a Map<String, Value>,
+  claim_name: &str,
+) -> Option<&'a Value> {
+  let (first, rest) = claim_name.split_once('.')?;
+  let mut value = claims.get(first)?;
+  for key in rest.split('.') {
+    value = value.as_object()?.get(key)?;
+  }
+  Some(value)
 }

--- a/bin/core/src/config.rs
+++ b/bin/core/src/config.rs
@@ -238,6 +238,15 @@ pub fn core_config() -> &'static CoreConfig {
       oidc_auto_redirect: env
         .komodo_oidc_auto_redirect
         .unwrap_or(config.oidc_auto_redirect),
+      oidc_sync_user_groups: env
+        .komodo_oidc_sync_user_groups
+        .unwrap_or(config.oidc_sync_user_groups),
+      oidc_sync_user_groups_claim: env
+        .komodo_oidc_sync_user_groups_claim
+        .unwrap_or(config.oidc_sync_user_groups_claim),
+      oidc_sync_user_groups_auto_create: env
+        .komodo_oidc_sync_user_groups_auto_create
+        .unwrap_or(config.oidc_sync_user_groups_auto_create),
       google_oauth: NamedOauthConfig {
         enabled: env
           .komodo_google_oauth_enabled

--- a/client/core/rs/src/entities/config/core.rs
+++ b/client/core/rs/src/entities/config/core.rs
@@ -176,6 +176,12 @@ pub struct Env {
   pub komodo_oidc_additional_audiences_file: Option<PathBuf>,
   /// Override `oidc_auto_redirect`
   pub komodo_oidc_auto_redirect: Option<bool>,
+  /// Override `oidc_sync_user_groups`
+  pub komodo_oidc_sync_user_groups: Option<bool>,
+  /// Override `oidc_sync_user_groups_claim`
+  pub komodo_oidc_sync_user_groups_claim: Option<String>,
+  /// Override `oidc_sync_user_groups_auto_create`
+  pub komodo_oidc_sync_user_groups_auto_create: Option<bool>,
 
   /// Override `google_oauth.enabled`
   pub komodo_google_oauth_enabled: Option<bool>,
@@ -562,6 +568,26 @@ pub struct CoreConfig {
   #[serde(default)]
   pub oidc_auto_redirect: bool,
 
+  /// Sync Komodo user group memberships from an OIDC claim on every OIDC login.
+  ///
+  /// Only memberships previously synced from OIDC are removed when claims change.
+  /// Manual group membership remains untouched.
+  #[serde(default)]
+  pub oidc_sync_user_groups: bool,
+
+  /// OIDC claim used for user group sync.
+  ///
+  /// Supports either an array of strings, a single string, or a dotted path
+  /// such as `realm_access.roles`.
+  #[serde(default = "default_oidc_sync_user_groups_claim")]
+  pub oidc_sync_user_groups_claim: String,
+
+  /// Create Komodo user groups found in OIDC claims when they do not exist.
+  ///
+  /// When false, only existing Komodo user groups are synced.
+  #[serde(default)]
+  pub oidc_sync_user_groups_auto_create: bool,
+
   // =========
   // = Oauth =
   // =========
@@ -883,6 +909,10 @@ fn default_ssl_cert_file() -> String {
   "/config/ssl/cert.pem".to_string()
 }
 
+fn default_oidc_sync_user_groups_claim() -> String {
+  String::from("groups")
+}
+
 impl Default for CoreConfig {
   fn default() -> Self {
     Self {
@@ -924,6 +954,10 @@ impl Default for CoreConfig {
       oidc_use_full_email: Default::default(),
       oidc_additional_audiences: Default::default(),
       oidc_auto_redirect: Default::default(),
+      oidc_sync_user_groups: Default::default(),
+      oidc_sync_user_groups_claim:
+        default_oidc_sync_user_groups_claim(),
+      oidc_sync_user_groups_auto_create: Default::default(),
       google_oauth: Default::default(),
       github_oauth: Default::default(),
       auth_rate_limit_disabled: Default::default(),
@@ -1029,6 +1063,10 @@ impl CoreConfig {
         .map(|aud| empty_or_redacted(aud))
         .collect(),
       oidc_auto_redirect: config.oidc_auto_redirect,
+      oidc_sync_user_groups: config.oidc_sync_user_groups,
+      oidc_sync_user_groups_claim: config.oidc_sync_user_groups_claim,
+      oidc_sync_user_groups_auto_create: config
+        .oidc_sync_user_groups_auto_create,
       google_oauth: NamedOauthConfig {
         enabled: config.google_oauth.enabled,
         client_id: empty_or_redacted(&config.google_oauth.client_id),

--- a/client/core/rs/src/entities/user.rs
+++ b/client/core/rs/src/entities/user.rs
@@ -68,6 +68,11 @@ pub struct User {
   #[serde(default)]
   pub linked_logins: LinkedLoginsMap,
 
+  /// User group names last synced from OIDC claims.
+  /// Used to reconcile OIDC-managed memberships without touching manual groups.
+  #[serde(default)]
+  pub oidc_synced_groups: Vec<String>,
+
   /// TOTP 2fa credentials
   #[serde(default)]
   pub totp: UserTotpConfig,
@@ -136,6 +141,7 @@ impl User {
       recents: Default::default(),
       all: Default::default(),
       linked_logins: Default::default(),
+      oidc_synced_groups: Default::default(),
       totp: Default::default(),
       passkey: Default::default(),
       external_skip_2fa: Default::default(),

--- a/client/core/ts/src/types.ts
+++ b/client/core/ts/src/types.ts
@@ -1160,6 +1160,11 @@ export interface User {
 	 * May not contain 'Service' type config.
 	 */
 	linked_logins?: LinkedLoginsMap;
+	/**
+	 * User group names last synced from OIDC claims.
+	 * Used to reconcile OIDC-managed memberships without touching manual groups.
+	 */
+	oidc_synced_groups?: string[];
 	/** TOTP 2fa credentials */
 	totp?: UserTotpConfig;
 	/** WebAuthn Passkey 2fa credentials */

--- a/compose/compose.env
+++ b/compose/compose.env
@@ -102,6 +102,17 @@ KOMODO_OIDC_ENABLED=false
 ## Add additional trusted audiences for token claims verification.
 ## Supports comma separated list, and passing with _FILE (for compose secrets).
 # KOMODO_OIDC_ADDITIONAL_AUDIENCES=abc,123 # Alt: KOMODO_OIDC_ADDITIONAL_AUDIENCES_FILE
+## Automatically redirect unauthenticated users to the OIDC provider.
+# KOMODO_OIDC_AUTO_REDIRECT=false
+## Sync Komodo User Group memberships from an OIDC claim on every OIDC login.
+## Only memberships previously synced from OIDC are removed when claims change.
+# KOMODO_OIDC_SYNC_USER_GROUPS=false
+## OIDC claim used for User Group sync.
+## Supports an array of strings, a single string, or a dotted path like `realm_access.roles`.
+# KOMODO_OIDC_SYNC_USER_GROUPS_CLAIM=groups
+## Create Komodo User Groups found in OIDC claims when they do not exist.
+## When false, only existing Komodo User Groups are synced.
+# KOMODO_OIDC_SYNC_USER_GROUPS_AUTO_CREATE=false
 
 ## Github Oauth
 KOMODO_GITHUB_OAUTH_ENABLED=false

--- a/config/core.config.toml
+++ b/config/core.config.toml
@@ -288,6 +288,25 @@ oidc_additional_audiences = []
 ## Default: false
 oidc_auto_redirect = false
 
+## Sync Komodo User Group memberships from an OIDC claim on every OIDC login.
+## Only memberships previously synced from OIDC are removed when claims change.
+## Manual group membership remains untouched.
+## Env: KOMODO_OIDC_SYNC_USER_GROUPS
+## Default: false
+oidc_sync_user_groups = false
+
+## OIDC claim used for User Group sync.
+## Supports an array of strings, a single string, or a dotted path like `realm_access.roles`.
+## Env: KOMODO_OIDC_SYNC_USER_GROUPS_CLAIM
+## Default: groups
+oidc_sync_user_groups_claim = "groups"
+
+## Create Komodo User Groups found in OIDC claims when they do not exist.
+## When false, only existing Komodo User Groups are synced.
+## Env: KOMODO_OIDC_SYNC_USER_GROUPS_AUTO_CREATE
+## Default: false
+oidc_sync_user_groups_auto_create = false
+
 #########
 # OAUTH #
 #########

--- a/config/core.config.toml
+++ b/config/core.config.toml
@@ -290,7 +290,6 @@ oidc_auto_redirect = false
 
 ## Sync Komodo User Group memberships from an OIDC claim on every OIDC login.
 ## Only memberships previously synced from OIDC are removed when claims change.
-## Manual group membership remains untouched.
 ## Env: KOMODO_OIDC_SYNC_USER_GROUPS
 ## Default: false
 oidc_sync_user_groups = false

--- a/ui/public/client/types.d.ts
+++ b/ui/public/client/types.d.ts
@@ -1316,6 +1316,11 @@ export interface User {
      * May not contain 'Service' type config.
      */
     linked_logins?: LinkedLoginsMap;
+    /**
+     * User group names last synced from OIDC claims.
+     * Used to reconcile OIDC-managed memberships without touching manual groups.
+     */
+    oidc_synced_groups?: string[];
     /** TOTP 2fa credentials */
     totp?: UserTotpConfig;
     /** WebAuthn Passkey 2fa credentials */


### PR DESCRIPTION
Adds support to automatically add (and optionally create) user groups to users in Komodo using OIDC claim data.

This requires an update to the underlying auth server Komodo uses. Upon the merge of [this PR](https://github.com/moghtech/lib/pull/6), this PR will be updated with the new release version and undrafted.

Config shape:
```
  ## Sync Komodo User Group memberships from an OIDC claim on every OIDC login.
  ## Only memberships previously synced from OIDC are removed when claims change.
  oidc_sync_user_groups = false

  ## OIDC claim used for User Group sync.
  ## Supports an array of strings, a single string, or a dotted path like
  `realm_access.roles`.
  oidc_sync_user_groups_claim = "groups"

  ## Create Komodo User Groups found in OIDC claims when they do not exist.
  ## When false, only existing Komodo User Groups are synced.
  oidc_sync_user_groups_auto_create = false
```

Closes: #667, #1251 


