### PR TITLE
feat: Allow resource syncs to self update

### DIFF
--- a/bin/core/src/api/execute/sync.rs
+++ b/bin/core/src/api/execute/sync.rs
@@ -49,6 +49,13 @@ use crate::{
 
 use super::ExecuteArgs;
 
+/// Maximum number of reconciliation passes performed by a single `RunSync`.
+///
+/// A second pass lets a sync that changed its own configuration apply the
+/// new scope immediately (when `rerun_on_self_change` is enabled), while
+/// guaranteeing the run always terminates.
+const MAX_SYNC_PASSES: u32 = 2;
+
 impl Resolve<ExecuteArgs> for RunSync {
   #[instrument(
     "RunSync",
@@ -81,16 +88,7 @@ impl Resolve<ExecuteArgs> for RunSync {
       PermissionLevel::Execute.into(),
     )
     .await?;
-
-    let repo = if !sync.config.files_on_host
-      && !sync.config.linked_repo.is_empty()
-    {
-      crate::resource::get::<Repo>(&sync.config.linked_repo)
-        .await?
-        .into()
-    } else {
-      None
-    };
+    let sync_id = sync.id.clone();
 
     // get the action state for the sync (or insert default).
     let action_state =
@@ -106,155 +104,249 @@ impl Resolve<ExecuteArgs> for RunSync {
     // Send update here for FE to recheck action state
     update_update(update.clone()).await?;
 
-    let RemoteResources {
-      resources,
-      logs,
-      hash,
-      message,
-      file_errors,
-      ..
-    } =
-      crate::sync::remote::get_remote_resources(&sync, repo.as_ref())
-        .await
-        .context("failed to get remote resources")?;
+    // Each pass reconciles against the sync config as it was when the pass
+    // started. A sync can declare itself among its managed resources; if it
+    // changes its own config during a pass, that new config only takes effect
+    // on the next pass (the current pass already loaded resources using the
+    // previous config). When `rerun_on_self_change` is enabled, run one extra
+    // pass so the new scope is applied without waiting for an external trigger.
+    let mut sync = sync;
+    let mut passes = 0u32;
+    loop {
+      passes += 1;
 
-    update.logs.extend(logs);
+      let outcome = execute_sync_pass(
+        &sync,
+        match_resource_type,
+        match_resources.as_deref(),
+        &mut update,
+      )
+      .await?;
+
+      if !outcome.no_changes
+        && outcome.self_config_changed
+        && sync.config.rerun_on_self_change
+        && passes < MAX_SYNC_PASSES
+      {
+        update.push_simple_log(
+          "Re-run sync",
+          format!(
+            "The sync modified its own configuration. {} to apply the updated scope.",
+            colored("re-running once", Color::Blue)
+          ),
+        );
+        update_update(update.clone()).await?;
+        // Re-read the (now updated) config for the next pass.
+        sync =
+          crate::resource::get::<entities::sync::ResourceSync>(
+            &sync_id,
+          )
+          .await?;
+        continue;
+      }
+
+      break;
+    }
+
+    update.finalize();
     update_update(update.clone()).await?;
 
-    if !file_errors.is_empty() {
-      return Err(
-        anyhow!("Found file errors. Cannot execute sync.").into(),
-      );
-    }
+    Ok(update)
+  }
+}
 
-    let resources = resources?;
+/// Outcome of a single sync reconciliation pass.
+struct SyncPassOutcome {
+  /// Nothing was out of sync this pass.
+  no_changes: bool,
+  /// The sync successfully updated its own config this pass (which may have
+  /// changed what it resolves on a subsequent pass).
+  self_config_changed: bool,
+}
 
-    let id_to_tags = get_id_to_tags(None).await?;
-    let all_resources = AllResourcesById::load().await?;
-    // Convert all match_resources to names
-    let match_resources = match_resources.map(|resources| {
-      resources
-        .into_iter()
-        .filter_map(|name_or_id| {
-          let Some(resource_type) = match_resource_type else {
-            return Some(name_or_id);
-          };
-          macro_rules! resolve_id_to_name {
-            ($(($Variant:ident, $field:ident)),* $(,)?) => {
-              match ObjectId::from_str(&name_or_id) {
-                Ok(_) => match resource_type {
-                  $(
-                    ResourceTargetVariant::$Variant => all_resources
-                      .$field
-                      .get(&name_or_id)
-                      .map(|r| r.name.clone()),
-                  )*
-                  ResourceTargetVariant::System => None,
-                },
-                Err(_) => Some(name_or_id),
-              }
-            };
-          }
-          // New resource types need to be added here manually.
-          resolve_id_to_name!(
-            (Server, servers),
-            (Swarm, swarms),
-            (Stack, stacks),
-            (Deployment, deployments),
-            (Build, builds),
-            (Repo, repos),
-            (Procedure, procedures),
-            (Action, actions),
-            (ResourceSync, syncs),
-            (Builder, builders),
-            (Alerter, alerters),
-          )
-        })
-        .collect::<Vec<_>>()
-    });
+/// Runs a single reconciliation pass: loads the remote resources using the
+/// sync's *current* config, computes the deltas and applies them. Logs are
+/// appended to `update`; the update is not finalized here.
+async fn execute_sync_pass(
+  sync: &ResourceSync,
+  match_resource_type: Option<ResourceTargetVariant>,
+  match_resources: Option<&[String]>,
+  update: &mut Update,
+) -> mogh_error::Result<SyncPassOutcome> {
+  let repo = if !sync.config.files_on_host
+    && !sync.config.linked_repo.is_empty()
+  {
+    crate::resource::get::<Repo>(&sync.config.linked_repo)
+      .await?
+      .into()
+  } else {
+    None
+  };
 
-    let deployments_by_name = all_resources
-      .deployments
-      .values()
-      .filter(|deployment| {
-        Deployment::include_resource(
-          &deployment.name,
-          &deployment.config,
-          match_resource_type,
-          match_resources.as_deref(),
-          &deployment.tags,
-          &id_to_tags,
-          &sync.config.match_tags,
-        )
-      })
-      .map(|deployment| (deployment.name.clone(), deployment.clone()))
-      .collect::<HashMap<_, _>>();
-    let stacks_by_name = all_resources
-      .stacks
-      .values()
-      .filter(|stack| {
-        Stack::include_resource(
-          &stack.name,
-          &stack.config,
-          match_resource_type,
-          match_resources.as_deref(),
-          &stack.tags,
-          &id_to_tags,
-          &sync.config.match_tags,
-        )
-      })
-      .map(|stack| (stack.name.clone(), stack.clone()))
-      .collect::<HashMap<_, _>>();
+  let RemoteResources {
+    resources,
+    logs,
+    hash,
+    message,
+    file_errors,
+    ..
+  } = crate::sync::remote::get_remote_resources(sync, repo.as_ref())
+    .await
+    .context("failed to get remote resources")?;
 
-    let deploy_cache = build_deploy_cache(SyncDeployParams {
-      deployments: &resources.deployments,
-      deployment_map: &deployments_by_name,
-      stacks: &resources.stacks,
-      stack_map: &stacks_by_name,
-    })
-    .await?;
+  update.logs.extend(logs);
+  update_update(update.clone()).await?;
 
-    let delete = sync.config.managed || sync.config.delete;
-
-    macro_rules! get_deltas {
-      ($(($var:ident, $Type:ident, $field:ident)),* $(,)?) => {
-        $(
-          let $var = if sync.config.include_resources {
-            get_updates_for_execution::<$Type>(
-              resources.$field,
-              delete,
-              match_resource_type,
-              match_resources.as_deref(),
-              &id_to_tags,
-              &sync.config.match_tags,
-            )
-            .await?
-          } else {
-            Default::default()
-          };
-        )*
-      };
-    }
-    // New resource types need to be added here manually.
-    get_deltas!(
-      (server_deltas, Server, servers),
-      (swarm_deltas, Swarm, swarms),
-      (stack_deltas, Stack, stacks),
-      (deployment_deltas, Deployment, deployments),
-      (build_deltas, Build, builds),
-      (repo_deltas, Repo, repos),
-      (procedure_deltas, Procedure, procedures),
-      (action_deltas, Action, actions),
-      (builder_deltas, Builder, builders),
-      (alerter_deltas, Alerter, alerters),
-      (resource_sync_deltas, ResourceSync, resource_syncs),
+  if !file_errors.is_empty() {
+    return Err(
+      anyhow!("Found file errors. Cannot execute sync.").into(),
     );
+  }
 
-    let (
-      variables_to_create,
-      variables_to_update,
-      variables_to_delete,
-    ) = if match_resource_type.is_none()
+  let resources = resources?;
+
+  let id_to_tags = get_id_to_tags(None).await?;
+  let all_resources = AllResourcesById::load().await?;
+  // Convert all match_resources to names
+  let match_resources = match_resources.map(|resources| {
+    resources
+      .iter()
+      .cloned()
+      .filter_map(|name_or_id| {
+        let Some(resource_type) = match_resource_type else {
+          return Some(name_or_id);
+        };
+        macro_rules! resolve_id_to_name {
+          ($(($Variant:ident, $field:ident)),* $(,)?) => {
+            match ObjectId::from_str(&name_or_id) {
+              Ok(_) => match resource_type {
+                $(
+                  ResourceTargetVariant::$Variant => all_resources
+                    .$field
+                    .get(&name_or_id)
+                    .map(|r| r.name.clone()),
+                )*
+                ResourceTargetVariant::System => None,
+              },
+              Err(_) => Some(name_or_id),
+            }
+          };
+        }
+        // New resource types need to be added here manually.
+        resolve_id_to_name!(
+          (Server, servers),
+          (Swarm, swarms),
+          (Stack, stacks),
+          (Deployment, deployments),
+          (Build, builds),
+          (Repo, repos),
+          (Procedure, procedures),
+          (Action, actions),
+          (ResourceSync, syncs),
+          (Builder, builders),
+          (Alerter, alerters),
+        )
+      })
+      .collect::<Vec<_>>()
+  });
+
+  let deployments_by_name = all_resources
+    .deployments
+    .values()
+    .filter(|deployment| {
+      Deployment::include_resource(
+        &deployment.name,
+        &deployment.config,
+        match_resource_type,
+        match_resources.as_deref(),
+        &deployment.tags,
+        &id_to_tags,
+        &sync.config.match_tags,
+      )
+    })
+    .map(|deployment| (deployment.name.clone(), deployment.clone()))
+    .collect::<HashMap<_, _>>();
+  let stacks_by_name = all_resources
+    .stacks
+    .values()
+    .filter(|stack| {
+      Stack::include_resource(
+        &stack.name,
+        &stack.config,
+        match_resource_type,
+        match_resources.as_deref(),
+        &stack.tags,
+        &id_to_tags,
+        &sync.config.match_tags,
+      )
+    })
+    .map(|stack| (stack.name.clone(), stack.clone()))
+    .collect::<HashMap<_, _>>();
+
+  let deploy_cache = build_deploy_cache(SyncDeployParams {
+    deployments: &resources.deployments,
+    deployment_map: &deployments_by_name,
+    stacks: &resources.stacks,
+    stack_map: &stacks_by_name,
+  })
+  .await?;
+
+  let delete = sync.config.managed || sync.config.delete;
+
+  macro_rules! get_deltas {
+    ($(($var:ident, $Type:ident, $field:ident)),* $(,)?) => {
+      $(
+        let $var = if sync.config.include_resources {
+          get_updates_for_execution::<$Type>(
+            resources.$field,
+            delete,
+            match_resource_type,
+            match_resources.as_deref(),
+            &id_to_tags,
+            &sync.config.match_tags,
+          )
+          .await?
+        } else {
+          Default::default()
+        };
+      )*
+    };
+  }
+  // New resource types need to be added here manually.
+  get_deltas!(
+    (server_deltas, Server, servers),
+    (swarm_deltas, Swarm, swarms),
+    (stack_deltas, Stack, stacks),
+    (deployment_deltas, Deployment, deployments),
+    (build_deltas, Build, builds),
+    (repo_deltas, Repo, repos),
+    (procedure_deltas, Procedure, procedures),
+    (action_deltas, Action, actions),
+    (builder_deltas, Builder, builders),
+    (alerter_deltas, Alerter, alerters),
+    (resource_sync_deltas, ResourceSync, resource_syncs),
+  );
+
+  // A running sync cannot delete itself. If delete/managed mode would remove
+  // the running sync (because it isn't declared in its own resource files),
+  // hard fail up front - before any resources are mutated - rather than
+  // silently skipping the deletion.
+  if resource_sync_deltas
+    .to_delete
+    .iter()
+    .any(|name| name == &sync.name)
+  {
+    return Err(
+      anyhow!(
+        "Sync '{}' is configured to delete itself: it is not declared in its own resource files while delete/managed mode is enabled. Declare it in the resource files, or remove it manually / disable delete mode.",
+        sync.name
+      )
+      .into(),
+    );
+  }
+
+  let (variables_to_create, variables_to_update, variables_to_delete) =
+    if match_resource_type.is_none()
       && match_resources.is_none()
       && sync.config.include_variables
     {
@@ -266,186 +358,198 @@ impl Resolve<ExecuteArgs> for RunSync {
     } else {
       Default::default()
     };
-    let (
+  let (
+    user_groups_to_create,
+    user_groups_to_update,
+    user_groups_to_delete,
+  ) = if match_resource_type.is_none()
+    && match_resources.is_none()
+    && sync.config.include_user_groups
+  {
+    crate::sync::user_groups::get_updates_for_execution(
+      resources.user_groups,
+      delete,
+    )
+    .await?
+  } else {
+    Default::default()
+  };
+
+  // New resource types need to be added here manually.
+  if deploy_cache.is_empty()
+    && resource_sync_deltas.no_changes()
+    && server_deltas.no_changes()
+    && swarm_deltas.no_changes()
+    && deployment_deltas.no_changes()
+    && stack_deltas.no_changes()
+    && build_deltas.no_changes()
+    && builder_deltas.no_changes()
+    && alerter_deltas.no_changes()
+    && repo_deltas.no_changes()
+    && procedure_deltas.no_changes()
+    && action_deltas.no_changes()
+    && user_groups_to_create.is_empty()
+    && user_groups_to_update.is_empty()
+    && user_groups_to_delete.is_empty()
+    && variables_to_create.is_empty()
+    && variables_to_update.is_empty()
+    && variables_to_delete.is_empty()
+  {
+    update.push_simple_log(
+      "No Changes",
+      format!("{}. exiting.", colored("nothing to do", Color::Green)),
+    );
+    return Ok(SyncPassOutcome {
+      no_changes: true,
+      self_config_changed: false,
+    });
+  }
+
+  // =====================================================
+  // The ordering these are executed does matter, since
+  // latter resources may depend on prior synced resources
+  // already being updated with the declared state.
+  // =====================================================
+
+  // No deps
+  maybe_extend(
+    &mut update.logs,
+    crate::sync::variables::run_updates(
+      variables_to_create,
+      variables_to_update,
+      variables_to_delete,
+    )
+    .await,
+  );
+  maybe_extend(
+    &mut update.logs,
+    crate::sync::user_groups::run_updates(
       user_groups_to_create,
       user_groups_to_update,
       user_groups_to_delete,
-    ) = if match_resource_type.is_none()
-      && match_resources.is_none()
-      && sync.config.include_user_groups
-    {
-      crate::sync::user_groups::get_updates_for_execution(
-        resources.user_groups,
-        delete,
-      )
-      .await?
-    } else {
-      Default::default()
-    };
-
-    // New resource types need to be added here manually.
-    if deploy_cache.is_empty()
-      && resource_sync_deltas.no_changes()
-      && server_deltas.no_changes()
-      && swarm_deltas.no_changes()
-      && deployment_deltas.no_changes()
-      && stack_deltas.no_changes()
-      && build_deltas.no_changes()
-      && builder_deltas.no_changes()
-      && alerter_deltas.no_changes()
-      && repo_deltas.no_changes()
-      && procedure_deltas.no_changes()
-      && action_deltas.no_changes()
-      && user_groups_to_create.is_empty()
-      && user_groups_to_update.is_empty()
-      && user_groups_to_delete.is_empty()
-      && variables_to_create.is_empty()
-      && variables_to_update.is_empty()
-      && variables_to_delete.is_empty()
-    {
-      update.push_simple_log(
-        "No Changes",
-        format!(
-          "{}. exiting.",
-          colored("nothing to do", Color::Green)
-        ),
-      );
-      update.finalize();
-      update_update(update.clone()).await?;
-      return Ok(update);
-    }
-
-    // =====================================================
-    // The ordering these are executed does matter, since
-    // latter resources may depend on prior synced resources
-    // already being updated with the declared state.
-    // =====================================================
-
-    // No deps
-    maybe_extend(
-      &mut update.logs,
-      crate::sync::variables::run_updates(
-        variables_to_create,
-        variables_to_update,
-        variables_to_delete,
-      )
-      .await,
-    );
-    maybe_extend(
-      &mut update.logs,
-      crate::sync::user_groups::run_updates(
-        user_groups_to_create,
-        user_groups_to_update,
-        user_groups_to_delete,
-      )
-      .await,
-    );
-
-    maybe_extend(
-      &mut update.logs,
-      Server::execute_sync_updates(server_deltas).await,
-    );
-    maybe_extend(
-      &mut update.logs,
-      Alerter::execute_sync_updates(alerter_deltas).await,
-    );
-    maybe_extend(
-      &mut update.logs,
-      Action::execute_sync_updates(action_deltas).await,
-    );
-
-    // Depends on server
-    maybe_extend(
-      &mut update.logs,
-      Swarm::execute_sync_updates(swarm_deltas).await,
-    );
-    // Depends on server
-    maybe_extend(
-      &mut update.logs,
-      Builder::execute_sync_updates(builder_deltas).await,
-    );
-    // Depends on server / builder
-    maybe_extend(
-      &mut update.logs,
-      Repo::execute_sync_updates(repo_deltas).await,
-    );
-
-    // Depends on builder / repo
-    maybe_extend(
-      &mut update.logs,
-      Build::execute_sync_updates(build_deltas).await,
-    );
-    // Depends on server / repo
-    maybe_extend(
-      &mut update.logs,
-      Stack::execute_sync_updates(stack_deltas).await,
-    );
-    // Depends on repo
-    maybe_extend(
-      &mut update.logs,
-      ResourceSync::execute_sync_updates(resource_sync_deltas).await,
-    );
-    // Depends on server / build
-    maybe_extend(
-      &mut update.logs,
-      Deployment::execute_sync_updates(deployment_deltas).await,
-    );
-    // Depends on everything
-    maybe_extend(
-      &mut update.logs,
-      Procedure::execute_sync_updates(procedure_deltas).await,
-    );
-
-    // Execute the deploy cache
-    deploy_from_cache(deploy_cache, &mut update.logs).await;
-
-    let db = db_client();
-
-    if let Err(e) = update_one_by_id(
-      &db.resource_syncs,
-      &sync.id,
-      doc! {
-        "$set": {
-          "info.last_sync_ts": komodo_timestamp(),
-          "info.last_sync_hash": hash,
-          "info.last_sync_message": message,
-        }
-      },
-      None,
     )
-    .await
-    {
-      warn!(
-        "failed to update resource sync {} info after sync | {e:#}",
-        sync.name
-      )
-    }
+    .await,
+  );
 
-    if let Err(e) = (RefreshResourceSyncPending { sync: sync.id })
-      .resolve(&WriteArgs {
-        user: sync_user().to_owned(),
-      })
-      .await
-    {
-      warn!(
-        "failed to refresh sync {} after run | {:#}",
-        sync.name, e.error
-      );
-      update.push_error_log(
-        "refresh sync",
-        format_serror(
-          &e.error
-            .context("failed to refresh sync pending after run")
-            .into(),
-        ),
-      );
-    }
+  maybe_extend(
+    &mut update.logs,
+    Server::execute_sync_updates(server_deltas).await,
+  );
+  maybe_extend(
+    &mut update.logs,
+    Alerter::execute_sync_updates(alerter_deltas).await,
+  );
+  maybe_extend(
+    &mut update.logs,
+    Action::execute_sync_updates(action_deltas).await,
+  );
 
-    update.finalize();
-    update_update(update.clone()).await?;
+  // Depends on server
+  maybe_extend(
+    &mut update.logs,
+    Swarm::execute_sync_updates(swarm_deltas).await,
+  );
+  // Depends on server
+  maybe_extend(
+    &mut update.logs,
+    Builder::execute_sync_updates(builder_deltas).await,
+  );
+  // Depends on server / builder
+  maybe_extend(
+    &mut update.logs,
+    Repo::execute_sync_updates(repo_deltas).await,
+  );
 
-    Ok(update)
+  // Depends on builder / repo
+  maybe_extend(
+    &mut update.logs,
+    Build::execute_sync_updates(build_deltas).await,
+  );
+  // Depends on server / repo
+  maybe_extend(
+    &mut update.logs,
+    Stack::execute_sync_updates(stack_deltas).await,
+  );
+  // Depends on repo
+  //
+  // A sync can declare itself among its managed resources. Apply those self
+  // changes first, bypassing the busy check that the running sync would
+  // otherwise trip ("ResourceSync busy"). This mutates the deltas in place so
+  // the regular execution below skips the sync's own entry.
+  let mut resource_sync_deltas = resource_sync_deltas;
+  let (self_logs, self_config_changed) =
+    crate::sync::execute::execute_self_sync_updates(
+      &mut resource_sync_deltas,
+      &sync.id,
+    )
+    .await;
+  update.logs.extend(self_logs);
+  maybe_extend(
+    &mut update.logs,
+    ResourceSync::execute_sync_updates(resource_sync_deltas).await,
+  );
+  // Depends on server / build
+  maybe_extend(
+    &mut update.logs,
+    Deployment::execute_sync_updates(deployment_deltas).await,
+  );
+  // Depends on everything
+  maybe_extend(
+    &mut update.logs,
+    Procedure::execute_sync_updates(procedure_deltas).await,
+  );
+
+  // Execute the deploy cache
+  deploy_from_cache(deploy_cache, &mut update.logs).await;
+
+  let db = db_client();
+
+  if let Err(e) = update_one_by_id(
+    &db.resource_syncs,
+    &sync.id,
+    doc! {
+      "$set": {
+        "info.last_sync_ts": komodo_timestamp(),
+        "info.last_sync_hash": hash,
+        "info.last_sync_message": message,
+      }
+    },
+    None,
+  )
+  .await
+  {
+    warn!(
+      "failed to update resource sync {} info after sync | {e:#}",
+      sync.name
+    )
   }
+
+  if let Err(e) = (RefreshResourceSyncPending {
+    sync: sync.id.clone(),
+  })
+  .resolve(&WriteArgs {
+    user: sync_user().to_owned(),
+  })
+  .await
+  {
+    warn!(
+      "failed to refresh sync {} after run | {:#}",
+      sync.name, e.error
+    );
+    update.push_error_log(
+      "refresh sync",
+      format_serror(
+        &e.error
+          .context("failed to refresh sync pending after run")
+          .into(),
+      ),
+    );
+  }
+
+  Ok(SyncPassOutcome {
+    no_changes: false,
+    self_config_changed,
+  })
 }
 
 fn maybe_extend(logs: &mut Vec<Log>, log: Option<Log>) {

--- a/bin/core/src/resource/mod.rs
+++ b/bin/core/src/resource/mod.rs
@@ -558,8 +558,33 @@ pub async fn create<T: KomodoResource>(
 
 pub async fn update<T: KomodoResource>(
   id_or_name: &str,
+  config: T::PartialConfig,
+  user: &User,
+) -> anyhow::Result<Resource<T::Config, T::Info>> {
+  update_inner::<T>(id_or_name, config, user, true).await
+}
+
+/// Like [update], but skips the "busy" check.
+///
+/// Used when a Resource Sync updates itself (it declares itself among its
+/// own managed resources). The running sync holds its own action state lock
+/// for the entire duration of the run, so the normal busy check would always
+/// reject the self update with a confusing "ResourceSync busy" error - leaving
+/// the sync permanently unable to converge. The update is safe to apply here
+/// because it runs sequentially as part of the in-progress sync.
+pub async fn update_ignore_busy<T: KomodoResource>(
+  id_or_name: &str,
+  config: T::PartialConfig,
+  user: &User,
+) -> anyhow::Result<Resource<T::Config, T::Info>> {
+  update_inner::<T>(id_or_name, config, user, false).await
+}
+
+async fn update_inner<T: KomodoResource>(
+  id_or_name: &str,
   mut config: T::PartialConfig,
   user: &User,
+  check_busy: bool,
 ) -> anyhow::Result<Resource<T::Config, T::Info>> {
   let resource = get_check_permissions::<T>(
     id_or_name,
@@ -568,7 +593,7 @@ pub async fn update<T: KomodoResource>(
   )
   .await?;
 
-  if T::busy(&resource.id).await? {
+  if check_busy && T::busy(&resource.id).await? {
     return Err(anyhow!("{} busy", T::resource_type()));
   }
 

--- a/bin/core/src/sync/execute.rs
+++ b/bin/core/src/sync/execute.rs
@@ -4,12 +4,15 @@ use anyhow::Context;
 use database::mungos::find::find_collect;
 use formatting::{Color, bold, colored, muted};
 use komodo_client::entities::{
-  ResourceTargetVariant, tag::Tag, toml::ResourceToml, update::Log,
-  user::sync_user,
+  ResourceTargetVariant, sync::ResourceSync, tag::Tag,
+  toml::ResourceToml, update::Log, user::sync_user,
 };
 use partial_derive2::MaybeNone;
 
-use crate::{api::write::WriteArgs, resource::ResourceMetaUpdate};
+use crate::{
+  api::write::WriteArgs,
+  resource::{KomodoResource, ResourceMetaUpdate},
+};
 
 use super::{ResourceSyncTrait, SyncDeltas, ToUpdateItem};
 
@@ -267,6 +270,109 @@ pub trait ExecuteResourceSync: ResourceSyncTrait {
       Log::simple(&stage, log)
     })
   }
+}
+
+/// Applies a Resource Sync's changes to itself, if it declares itself among
+/// its own managed resources.
+///
+/// The running sync holds its own action state lock for the entire run, so
+/// routing the self update through the normal sync execution would fail the
+/// busy check with a confusing "ResourceSync busy" error, and the sync could
+/// never converge. This pulls the sync's own update entry out of the deltas
+/// (so the regular execution skips it) and applies it directly via
+/// [`update_ignore_busy`](crate::resource::update_ignore_busy), which skips
+/// the busy check (safe, since it runs sequentially within the in-progress
+/// sync).
+///
+/// Self *deletion* is not handled here - it is rejected up front by the
+/// caller (a running sync deleting itself is a hard error, not a silent skip).
+///
+/// Returns the logs plus a flag indicating whether the sync's own *config*
+/// was successfully changed (meta-only changes like tags/description don't
+/// count, since they can't alter what the sync resolves). The caller uses
+/// this to optionally re-run the sync (see `rerun_on_self_change`).
+pub async fn execute_self_sync_updates(
+  deltas: &mut SyncDeltas<<ResourceSync as KomodoResource>::PartialConfig>,
+  self_id: &str,
+) -> (Vec<Log>, bool) {
+  let stage = format!("Update {}s", ResourceSync::resource_type());
+  let mut logs = Vec::new();
+  let mut config_changed = false;
+
+  let Some(pos) =
+    deltas.to_update.iter().position(|item| item.id == self_id)
+  else {
+    return (logs, config_changed);
+  };
+
+  let ToUpdateItem {
+    id,
+    resource,
+    update_description,
+    update_template,
+    update_tags,
+  } = deltas.to_update.remove(pos);
+
+  let name = resource.name.clone();
+  let mut has_error = false;
+  let mut log = format!(
+    "running self update on {} '{}'",
+    ResourceSync::resource_type(),
+    bold(&name)
+  );
+
+  let meta = ResourceMetaUpdate {
+    description: update_description
+      .then(|| resource.description.clone()),
+    template: update_template.then_some(resource.template),
+    tags: update_tags.then(|| resource.tags.clone()),
+  };
+
+  if !meta.is_none() {
+    run_update_meta::<ResourceSync>(
+      id.clone(),
+      &name,
+      meta,
+      &mut log,
+      &mut has_error,
+    )
+    .await;
+  }
+
+  if !resource.config.is_none() {
+    if let Err(e) = crate::resource::update_ignore_busy::<ResourceSync>(
+      &id,
+      resource.config,
+      sync_user(),
+    )
+    .await
+    {
+      has_error = true;
+      log.push_str(&format!(
+        "\n{}: failed to update config on {} '{}' | {e:#}",
+        colored("ERROR", Color::Red),
+        ResourceSync::resource_type(),
+        bold(&name),
+      ))
+    } else {
+      config_changed = true;
+      log.push_str(&format!(
+        "\n{}: {} {} '{}' configuration",
+        muted("INFO"),
+        colored("updated", Color::Blue),
+        ResourceSync::resource_type(),
+        bold(&name)
+      ));
+    }
+  }
+
+  logs.push(if has_error {
+    Log::error(&stage, log)
+  } else {
+    Log::simple(&stage, log)
+  });
+
+  (logs, config_changed)
 }
 
 pub async fn run_update_meta<Resource: ResourceSyncTrait>(

--- a/client/core/rs/src/entities/sync.rs
+++ b/client/core/rs/src/entities/sync.rs
@@ -290,6 +290,16 @@ pub struct ResourceSyncConfig {
   #[partial_default(default_include_resources())]
   pub include_resources: bool,
 
+  /// If the sync declares itself among its managed resources, applying
+  /// its own config change only takes effect on the *next* run (the current
+  /// run already loaded resources using the previous config). When enabled,
+  /// the sync will automatically run a second time immediately after a run
+  /// in which it modified its own configuration, so the new scope is applied
+  /// without waiting for an external trigger.
+  #[serde(default)]
+  #[builder(default)]
+  pub rerun_on_self_change: bool,
+
   /// When using `managed` resource sync, will only export resources
   /// matching all of the given tags. If none, will match all resources.
   #[serde(default, deserialize_with = "string_list_deserializer")]
@@ -383,6 +393,7 @@ impl Default for ResourceSyncConfig {
       file_contents: Default::default(),
       managed: Default::default(),
       include_resources: default_include_resources(),
+      rerun_on_self_change: Default::default(),
       match_tags: Default::default(),
       include_variables: Default::default(),
       include_user_groups: Default::default(),

--- a/client/core/ts/src/types.ts
+++ b/client/core/ts/src/types.ts
@@ -2140,6 +2140,15 @@ export interface ResourceSyncConfig {
 	 */
 	include_resources: boolean;
 	/**
+	 * If the sync declares itself among its managed resources, applying
+	 * its own config change only takes effect on the *next* run (the current
+	 * run already loaded resources using the previous config). When enabled,
+	 * the sync will automatically run a second time immediately after a run
+	 * in which it modified its own configuration, so the new scope is applied
+	 * without waiting for an external trigger.
+	 */
+	rerun_on_self_change?: boolean;
+	/**
 	 * When using `managed` resource sync, will only export resources
 	 * matching all of the given tags. If none, will match all resources.
 	 */

--- a/docsite/docs/automate/sync-resources.md
+++ b/docsite/docs/automate/sync-resources.md
@@ -252,7 +252,26 @@ git_provider = "git.mogh.tech" # use an alternate git provider (default is githu
 git_account = "mbecker20"
 repo = "moghtech/komodo"
 resource_path = ["stacks.toml", "repos.toml"]
+# If the sync manages itself (declares its own resource above) and changes its
+# own config during a run, run once more automatically to apply the new scope.
+# Default: false
+rerun_on_self_change = true
 ```
+
+:::info Syncs that manage themselves
+A sync can declare itself among its managed resources. Komodo applies the
+sync's changes to itself during the run (no more "ResourceSync busy" errors).
+
+Because a run reconciles using the config that was active when it started, a
+change the sync makes to its own config (for example a new `resource_path`)
+only takes effect on the **next** run — after the first run the sync simply
+shows `Pending` again. Enable `rerun_on_self_change` to have it run once more
+automatically and apply the new scope immediately.
+
+A sync can never delete itself: if `delete`/`managed` mode is enabled and the
+sync is not declared in its own resource files, the run fails up front with a
+clear error (before changing anything) instead of silently skipping it.
+:::
 
 ### User Group:
 

--- a/ui/public/client/types.d.ts
+++ b/ui/public/client/types.d.ts
@@ -2297,6 +2297,15 @@ export interface ResourceSyncConfig {
      */
     include_resources: boolean;
     /**
+     * If the sync declares itself among its managed resources, applying
+     * its own config change only takes effect on the *next* run (the current
+     * run already loaded resources using the previous config). When enabled,
+     * the sync will automatically run a second time immediately after a run
+     * in which it modified its own configuration, so the new scope is applied
+     * without waiting for an external trigger.
+     */
+    rerun_on_self_change?: boolean;
+    /**
      * When using `managed` resource sync, will only export resources
      * matching all of the given tags. If none, will match all resources.
      */

--- a/ui/src/resources/sync/config.tsx
+++ b/ui/src/resources/sync/config.tsx
@@ -162,6 +162,11 @@ export default function ResourceSyncConfig({
         description:
           "Enabled managed mode / the 'Commit' button. Commit is the 'reverse' of Execute, and will update the sync file with your configs updated in the UI.",
       },
+      rerun_on_self_change: {
+        label: "Re-run On Self Change",
+        description:
+          "If the sync manages itself and updates its own config during a run, automatically run once more to apply the new scope (instead of waiting for the next trigger).",
+      },
     },
   };
 


### PR DESCRIPTION
# Let resource syncs sync themselves

Fixes #676

## What this does

A resource sync can declare *itself* among the resources it manages. Before
this change, running such a sync - when its own config had changed - always
failed with **`ResourceSync busy`** and left the sync stuck in `Pending` with
no clear recovery path. The only workarounds were removing the sync's own
declaration from the TOML, or hand-editing the UI config to match git exactly.

This PR makes a sync able to apply changes to itself during its own run, adds
an opt-in to immediately re-run when a sync changes its own scope, and turns
the "a sync would delete itself" case into an explicit hard error instead of a
confusing busy failure.

## Why it happened

When a sync runs, it takes its own action-state lock (`syncing = true`) for the
entire run. Applying the sync's own changes goes through
`resource::update::<ResourceSync>`, which starts with a busy check:

```rust
if T::busy(&resource.id).await? {
  return Err(anyhow!("{} busy", T::resource_type()));
}
```

Because the sync is the thing holding the lock, this check always trips for the
sync's own entry - so it could never converge.

## How it works

### 1. Apply self-updates, bypassing the busy check

- `resource::update` was split into `update` (unchanged, busy-checked) and a new
  `update_ignore_busy`, sharing a private `update_inner(..., check_busy: bool)`.
  No other call sites change.
- A new `execute_self_sync_updates` pulls the sync's own entry out of the
  `ResourceSync` deltas and applies the config update directly via
  `update_ignore_busy`. This is safe: it runs sequentially as part of the
  in-progress sync, not concurrently. (Tag/description/template meta updates
  already worked, since `update_meta` has no busy check.)

### 2. Optional re-run when a sync changes its own scope (`rerun_on_self_change`)

A run reconciles against the config that was active when the run *started*. If a
sync changes its own config mid-run (e.g. a new `resource_path`), that new scope
only takes effect on the **next** run - the end-of-run `RefreshResourceSyncPending`
correctly recomputes pending against the new config, so the sync simply shows
`Pending` again (it does **not** get falsely marked "in sync").

New opt-in config field `rerun_on_self_change` (default `false`): when the sync
successfully changed its own config during a pass, run one more pass immediately
to apply the new scope, instead of waiting for an external trigger.

To support this, `RunSync::resolve` was refactored so the per-pass reconciliation
lives in `execute_sync_pass(...)`, driven by a small loop hard-capped at
`MAX_SYNC_PASSES = 2`. The cap guarantees termination even if a sync's TOML never
quite diff-matches itself; if it's still `Pending` after the second pass it stays
`Pending`.

### 3. A sync can never delete itself (hard fail)

If `delete`/`managed` mode is enabled and the running sync is **not** declared in
its own resource files, it would otherwise be marked for deletion. This now
**hard-fails the run up front** - before any resource is mutated - with a clear
message, rather than silently skipping the deletion or failing as "busy":

> Sync '<name>' is configured to delete itself: it is not declared in its own
> resource files while delete/managed mode is enabled. Declare it in the
> resource files, or remove it manually / disable delete mode.

Failing early (right after deltas are computed) avoids a half-applied sync.

## Behavior summary

| Scenario | Before | After |
| --- | --- | --- |
| Sync changes its own config | `ResourceSync busy`, stuck `Pending` | Applied during the run |
| `rerun_on_self_change` off (default) | n/a | First run applies the self change; new scope shows as `Pending` |
| `rerun_on_self_change` on | n/a | Runs once more automatically to apply the new scope |
| Sync would delete itself (delete/managed, not self-declared) | `ResourceSync busy` | Hard error before any mutation |

## Changes

- `bin/core/src/resource/mod.rs` - split `update` into `update` /
  `update_ignore_busy` / `update_inner(check_busy)`.
- `bin/core/src/sync/execute.rs` - `execute_self_sync_updates` (applies the
  sync's own update, bypassing busy; returns whether config changed).
- `bin/core/src/api/execute/sync.rs` - extracted `execute_sync_pass`, added the
  capped re-run loop and the early self-delete hard fail.
- `client/core/rs/src/entities/sync.rs` - new `rerun_on_self_change` config
  field (default `false`).
- `client/core/ts/src/types.ts`, `ui/public/client/types.d.ts` - generated TS
  type for the new field.
- `ui/src/resources/sync/config.tsx` - "Re-run On Self Change" toggle.
- `docsite/docs/automate/sync-resources.md` - documents self-managing syncs, the
  new option, and the self-delete hard fail.

## Testing

- `cargo check -p komodo_core` and `-p komodo_client` pass with no warnings.
- Tested against local dev instance, see screenshots below.

## Screenshots

<img width="1345" height="1442" alt="image" src="https://github.com/user-attachments/assets/bda71add-f163-41a1-bb54-06cd120930f2" />

<img width="1319" height="293" alt="image" src="https://github.com/user-attachments/assets/dd1e33b3-ea6f-4039-8246-96162f861b58" />
