### PR TITLE
Add native MQTT alerter endpoint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,7 @@ svi = "1.2.0"
 
 # ASYNC
 reqwest = { version = "0.13.3", default-features = false, features = ["json", "stream", "form", "query", "rustls"] }
+rumqttc = "0.25.0"
 tokio = { version = "1.52.2", features = ["full"] }
 tokio-util = { version = "0.7.18", features = ["io", "codec"] }
 tokio-stream = { version = "0.1.18", features = ["sync"] }

--- a/MQTT_ALERTER_PLAN.md
+++ b/MQTT_ALERTER_PLAN.md
@@ -1,0 +1,39 @@
+# MQTT Alerter Plan
+
+## Minimum Files To Modify
+
+- `client/core/rs/src/entities/alerter.rs`
+  - Add a new `AlerterEndpoint::Mqtt` variant and `MqttAlerterEndpoint` config struct.
+  - Define defaults (topic `komodo/events`, QoS default) and optional auth/client fields.
+  - Keeps API/resource model aligned for backend + UI.
+
+- `client/core/ts/src/types.ts`
+  - Add generated-type equivalents for the new Rust endpoint variant and params.
+  - Ensures UI can type-check new MQTT config fields.
+
+- `bin/core/src/alert/mod.rs`
+  - Register `mod mqtt;`.
+  - Add endpoint dispatch arm for `AlerterEndpoint::Mqtt`.
+
+- `bin/core/src/alert/mqtt.rs` (new)
+  - Implement MQTT transport: connect, serialize existing `Alert` JSON unchanged, publish, and return success/failure.
+
+- `Cargo.toml` and `bin/core/Cargo.toml`
+  - Add MQTT client crate dependency needed by core alert transport.
+
+- `ui/src/resources/alerter/config/endpoint.tsx`
+  - Add `MQTT` to endpoint selector.
+  - Render MQTT-specific config fields: broker URL, topic, username, password, client ID, QoS, retain.
+
+- `docsite/docs/resources.md`
+  - Small docs update to include MQTT as a native Alerter destination.
+
+## Recommended Rust MQTT Library
+
+Use `rumqttc`.
+
+Why:
+- Pure Rust + Tokio-native async flow (fits Komodo core runtime).
+- Lightweight for one-shot publish operations.
+- Actively used in Rust MQTT integrations.
+- Supports auth, QoS levels, retain flag, and broker URL parsing patterns we need.

--- a/bin/core/Cargo.toml
+++ b/bin/core/Cargo.toml
@@ -64,6 +64,7 @@ serde_qs.workspace = true
 colored.workspace = true
 tracing.workspace = true
 reqwest.workspace = true
+rumqttc.workspace = true
 dotenvy.workspace = true
 anyhow.workspace = true
 bcrypt.workspace = true

--- a/bin/core/src/alert/mod.rs
+++ b/bin/core/src/alert/mod.rs
@@ -18,6 +18,7 @@ use crate::helpers::{
 use crate::{config::core_config, state::db_client};
 
 mod discord;
+mod mqtt;
 mod ntfy;
 mod pushover;
 mod slack;
@@ -148,6 +149,14 @@ pub async fn send_alert_to_alerter(
         )
       })
     }
+    AlerterEndpoint::Mqtt(mqtt_endpoint) => mqtt::send_alert(
+      mqtt_endpoint,
+      alert,
+    )
+    .await
+    .with_context(|| {
+      format!("Failed to send alert to MQTT Alerter {}", alerter.name)
+    }),
   }
 }
 

--- a/bin/core/src/alert/mqtt.rs
+++ b/bin/core/src/alert/mqtt.rs
@@ -35,8 +35,7 @@ pub async fn send_alert(
     if let Some(value) = client_id.as_mut() {
       interpolator.interpolate_string(value)?;
     }
-    let topic = topic
-      .replace("{data.type}", &AlertDataVariant::from(&alert.data).to_string());
+    let topic = topic;
 
     send_message(
       &broker_url,

--- a/bin/core/src/alert/mqtt.rs
+++ b/bin/core/src/alert/mqtt.rs
@@ -1,0 +1,163 @@
+use std::time::Duration;
+
+use anyhow::{Context, anyhow, bail};
+use komodo_client::entities::alert::AlertDataVariant;
+use rumqttc::{AsyncClient, MqttOptions, Packet, QoS};
+use url::Url;
+
+use super::*;
+
+pub async fn send_alert(
+  endpoint: &MqttAlerterEndpoint,
+  alert: &Alert,
+) -> anyhow::Result<()> {
+  let VariablesAndSecrets { variables, secrets } =
+    get_variables_and_secrets().await?;
+
+  let mut broker_url = endpoint.broker_url.clone();
+  let mut topic = endpoint.topic.clone();
+  let mut username = endpoint.username.clone();
+  let mut password = endpoint.password.clone();
+  let mut client_id = endpoint.client_id.clone();
+
+  let mut interpolator =
+    Interpolator::new(Some(&variables), &secrets);
+
+  let res = async {
+    interpolator.interpolate_string(&mut broker_url)?;
+    interpolator.interpolate_string(&mut topic)?;
+    if let Some(value) = username.as_mut() {
+      interpolator.interpolate_string(value)?;
+    }
+    if let Some(value) = password.as_mut() {
+      interpolator.interpolate_string(value)?;
+    }
+    if let Some(value) = client_id.as_mut() {
+      interpolator.interpolate_string(value)?;
+    }
+    let topic = topic
+      .replace("{data.type}", &AlertDataVariant::from(&alert.data).to_string());
+
+    send_message(
+      &broker_url,
+      &topic,
+      username.as_deref(),
+      password.as_deref(),
+      client_id.as_deref(),
+      endpoint.qos,
+      endpoint.retain,
+      alert,
+    )
+    .await
+  }
+  .await;
+
+  res.map_err(|e| {
+    let replacers = interpolator
+      .secret_replacers
+      .into_iter()
+      .collect::<Vec<_>>();
+    let sanitized_error =
+      svi::replace_in_string(&format!("{e:?}"), &replacers);
+    anyhow!("Error with publish to MQTT: {sanitized_error}")
+  })
+}
+
+async fn send_message(
+  broker_url: &str,
+  topic: &str,
+  username: Option<&str>,
+  password: Option<&str>,
+  client_id: Option<&str>,
+  qos: u8,
+  retain: bool,
+  alert: &Alert,
+) -> anyhow::Result<()> {
+  if topic.trim().is_empty() {
+    bail!("MQTT topic cannot be empty");
+  }
+
+  let parsed = Url::parse(broker_url).with_context(|| {
+    format!("Invalid MQTT broker URL: {broker_url}")
+  })?;
+  let scheme = parsed.scheme();
+  if !matches!(scheme, "mqtt" | "tcp") {
+    bail!(
+      "Unsupported MQTT broker URL scheme `{scheme}`. Use mqtt:// or tcp://"
+    );
+  }
+
+  let host = parsed
+    .host_str()
+    .context("MQTT broker URL must include a host")?;
+  let port = parsed
+    .port_or_known_default()
+    .context("MQTT broker URL must include a port")?;
+
+  let client_id = client_id
+    .filter(|id| !id.trim().is_empty())
+    .map(ToOwned::to_owned)
+    .unwrap_or_else(|| format!("komodo-alert-{}", uuid::Uuid::new_v4()));
+
+  let mut options = MqttOptions::new(client_id, host, port);
+  options.set_keep_alive(Duration::from_secs(10));
+
+  let url_username = parsed.username();
+  let url_password = parsed.password();
+  match (username, password) {
+    (Some(user), Some(pass)) => {
+      options.set_credentials(user, pass);
+    }
+    (Some(user), None) => {
+      options.set_credentials(user, "");
+    }
+    (None, Some(pass)) => {
+      options.set_credentials("", pass);
+    }
+    (None, None) if !url_username.is_empty() => {
+      options.set_credentials(url_username, url_password.unwrap_or(""));
+    }
+    _ => {}
+  }
+
+  let payload = serde_json::to_vec(alert)
+    .context("Failed to serialize alert payload to JSON")?;
+  let qos = to_qos(qos)?;
+
+  let (client, mut eventloop) = AsyncClient::new(options, 10);
+  client
+    .publish(topic, qos, retain, payload)
+    .await
+    .context("Failed queuing MQTT publish")?;
+
+  let poll_count = if qos == QoS::AtMostOnce { 2 } else { 4 };
+  for _ in 0..poll_count {
+    let event = tokio::time::timeout(
+      Duration::from_secs(5),
+      eventloop.poll(),
+    )
+    .await
+    .context("Timed out waiting for MQTT broker response")?
+    .context("MQTT event loop failed while publishing")?;
+
+    if matches!(
+      event,
+      rumqttc::Event::Incoming(Packet::PubAck(_))
+        | rumqttc::Event::Incoming(Packet::PubComp(_))
+    ) {
+      break;
+    }
+  }
+
+  client.disconnect().await.ok();
+  Ok(())
+}
+
+fn to_qos(qos: u8) -> anyhow::Result<QoS> {
+  match qos {
+    0 => Ok(QoS::AtMostOnce),
+    1 => Ok(QoS::AtLeastOnce),
+    2 => Ok(QoS::ExactlyOnce),
+    _ => bail!("Invalid MQTT QoS `{qos}`. Must be 0, 1, or 2"),
+  }
+}

--- a/bin/core/src/alert/mqtt.rs
+++ b/bin/core/src/alert/mqtt.rs
@@ -90,9 +90,7 @@ async fn send_message(
   let host = parsed
     .host_str()
     .context("MQTT broker URL must include a host")?;
-  let port = parsed
-    .port_or_known_default()
-    .context("MQTT broker URL must include a port")?;
+  let port = parsed.port().unwrap_or(1883);
 
   let client_id = client_id
     .filter(|id| !id.trim().is_empty())
@@ -102,8 +100,10 @@ async fn send_message(
   let mut options = MqttOptions::new(client_id, host, port);
   options.set_keep_alive(Duration::from_secs(10));
 
+  let username = username.filter(|value| !value.trim().is_empty());
+  let password = password.filter(|value| !value.trim().is_empty());
   let url_username = parsed.username();
-  let url_password = parsed.password();
+  let url_password = parsed.password().filter(|value| !value.is_empty());
   match (username, password) {
     (Some(user), Some(pass)) => {
       options.set_credentials(user, pass);

--- a/client/core/rs/src/entities/alert.rs
+++ b/client/core/rs/src/entities/alert.rs
@@ -59,11 +59,11 @@ pub struct Alert {
 /// The variants of data related to the alert.
 #[typeshare]
 #[derive(Serialize, Deserialize, Debug, Clone, EnumDiscriminants)]
-#[strum_discriminants(name(AlertDataVariant))]
+#[strum_discriminants(name(AlertDataVariant), derive(Display))]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[cfg_attr(
   not(feature = "utoipa"),
-  strum_discriminants(derive(Serialize, Deserialize, Hash))
+  strum_discriminants(derive(Serialize, Deserialize, Hash, Display))
 )]
 #[cfg_attr(
   feature = "utoipa",
@@ -71,6 +71,7 @@ pub struct Alert {
     Serialize,
     Deserialize,
     Hash,
+    Display,
     utoipa::ToSchema
   ))
 )]

--- a/client/core/rs/src/entities/alert.rs
+++ b/client/core/rs/src/entities/alert.rs
@@ -63,7 +63,7 @@ pub struct Alert {
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[cfg_attr(
   not(feature = "utoipa"),
-  strum_discriminants(derive(Serialize, Deserialize, Hash, Display))
+  strum_discriminants(derive(Serialize, Deserialize, Hash))
 )]
 #[cfg_attr(
   feature = "utoipa",
@@ -71,7 +71,6 @@ pub struct Alert {
     Serialize,
     Deserialize,
     Hash,
-    Display,
     utoipa::ToSchema
   ))
 )]

--- a/client/core/rs/src/entities/alert.rs
+++ b/client/core/rs/src/entities/alert.rs
@@ -59,7 +59,7 @@ pub struct Alert {
 /// The variants of data related to the alert.
 #[typeshare]
 #[derive(Serialize, Deserialize, Debug, Clone, EnumDiscriminants)]
-#[strum_discriminants(name(AlertDataVariant), derive(Display))]
+#[strum_discriminants(name(AlertDataVariant))]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[cfg_attr(
   not(feature = "utoipa"),

--- a/client/core/rs/src/entities/alerter.rs
+++ b/client/core/rs/src/entities/alerter.rs
@@ -170,6 +170,9 @@ pub enum AlerterEndpoint {
 
   /// Send alert to Pushover
   Pushover(PushoverAlerterEndpoint),
+
+  /// Send alert JSON to an MQTT broker
+  Mqtt(MqttAlerterEndpoint),
 }
 
 impl Default for AlerterEndpoint {
@@ -317,6 +320,66 @@ fn default_pushover_url() -> String {
   String::from(
     "https://api.pushover.net/1/messages.json?token=XXXXXXXXXXXXX&user=XXXXXXXXXXXXX",
   )
+}
+
+/// Configuration for an MQTT alerter.
+#[typeshare]
+#[derive(
+  Debug, Clone, PartialEq, Serialize, Deserialize, Builder,
+)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+pub struct MqttAlerterEndpoint {
+  /// MQTT broker URL. Example: `mqtt://localhost:1883`
+  #[serde(default = "default_mqtt_broker_url")]
+  #[builder(default = "default_mqtt_broker_url()")]
+  pub broker_url: String,
+
+  /// Topic to publish alerts to
+  #[serde(default = "default_mqtt_topic")]
+  #[builder(default = "default_mqtt_topic()")]
+  pub topic: String,
+
+  /// Optional username for broker authentication
+  pub username: Option<String>,
+
+  /// Optional password for broker authentication
+  pub password: Option<String>,
+
+  /// Optional client identifier. If empty, core will generate one.
+  pub client_id: Option<String>,
+
+  /// MQTT QoS level: 0, 1, or 2
+  #[serde(default)]
+  #[builder(default)]
+  pub qos: u8,
+
+  /// Whether the broker should retain the message
+  #[serde(default)]
+  #[builder(default)]
+  pub retain: bool,
+}
+
+impl Default for MqttAlerterEndpoint {
+  fn default() -> Self {
+    Self {
+      broker_url: default_mqtt_broker_url(),
+      topic: default_mqtt_topic(),
+      username: None,
+      password: None,
+      client_id: None,
+      qos: 0,
+      retain: false,
+    }
+  }
+}
+
+fn default_mqtt_broker_url() -> String {
+  String::from("mqtt://localhost:1883")
+}
+
+fn default_mqtt_topic() -> String {
+  String::from("komodo/events")
 }
 
 // QUERY

--- a/client/core/ts/src/types.ts
+++ b/client/core/ts/src/types.ts
@@ -227,7 +227,9 @@ export type AlerterEndpoint =
 	/** Send alert to Ntfy */
 	| { type: "Ntfy", params: NtfyAlerterEndpoint }
 	/** Send alert to Pushover */
-	| { type: "Pushover", params: PushoverAlerterEndpoint };
+	| { type: "Pushover", params: PushoverAlerterEndpoint }
+	/** Send alert JSON to an MQTT broker */
+	| { type: "Mqtt", params: MqttAlerterEndpoint };
 
 /** Used to reference a specific resource across all resource types */
 export type ResourceTarget = 
@@ -9148,6 +9150,24 @@ export interface NtfyAlerterEndpoint {
 	 * SMTP must be configured on the ntfy server.
 	 */
 	email?: string;
+}
+
+/** Configuration for an MQTT alerter. */
+export interface MqttAlerterEndpoint {
+	/** MQTT broker URL. Example: `mqtt://localhost:1883` */
+	broker_url: string;
+	/** Topic to publish alerts to */
+	topic: string;
+	/** Optional username for broker authentication */
+	username?: string;
+	/** Optional password for broker authentication */
+	password?: string;
+	/** Optional client identifier. If empty, core will generate one. */
+	client_id?: string;
+	/** MQTT QoS level: 0, 1, or 2 */
+	qos: number;
+	/** Whether the broker should retain the message */
+	retain: boolean;
 }
 
 /** Pauses all containers on the target server. Response: [Update] */

--- a/docsite/docs/resources.md
+++ b/docsite/docs/resources.md
@@ -70,4 +70,5 @@ All resources which depend on git repos / docker registries are able to use thes
 ## Alerter
 
 - Route alerts to various endpoints.
+- Native endpoints include `Discord`, `Slack`, `Ntfy`, `Pushover`, `MQTT`, and `Custom`.
 - Can configure rules on each Alerter, such as resource whitelist, blacklist, or alert type filter.

--- a/ui/src/resources/alerter/config/endpoint.tsx
+++ b/ui/src/resources/alerter/config/endpoint.tsx
@@ -2,12 +2,16 @@ import { MonacoEditor, ConfigInput, ConfigItem } from "mogh_ui";
 import { Select } from "@mantine/core";
 import { Types } from "komodo_client";
 
-const ENDPOINT_TYPES: Types.AlerterEndpoint["type"][] = [
-  "Custom",
-  "Discord",
-  "Slack",
-  "Ntfy",
-  "Pushover",
+const ENDPOINT_TYPES: {
+  value: Types.AlerterEndpoint["type"];
+  label: string;
+}[] = [
+  { value: "Custom", label: "Custom" },
+  { value: "Discord", label: "Discord" },
+  { value: "Slack", label: "Slack" },
+  { value: "Ntfy", label: "Ntfy" },
+  { value: "Pushover", label: "Pushover" },
+  { value: "Mqtt", label: "MQTT" },
 ] as const;
 
 export default function AlerterConfigEndpoint({
@@ -29,25 +33,22 @@ export default function AlerterConfigEndpoint({
           value={endpoint.type}
           onChange={(type) =>
             type &&
-            set({
-              type: type as Types.AlerterEndpoint["type"],
-              params: {
-                url: defaultUrl(type as Types.AlerterEndpoint["type"]),
-              },
-            })
+            set(defaultEndpoint(type as Types.AlerterEndpoint["type"]))
           }
           disabled={disabled}
           data={ENDPOINT_TYPES}
           w={{ base: "85%", lg: 400 }}
         />
-        <MonacoEditor
-          value={endpoint.params.url}
-          language={undefined}
-          onValueChange={(url) =>
-            set({ ...endpoint, params: { ...endpoint.params, url } })
-          }
-          readOnly={disabled}
-        />
+        {endpoint.type !== "Mqtt" && (
+          <MonacoEditor
+            value={endpoint.params.url}
+            language={undefined}
+            onValueChange={(url) =>
+              set({ ...endpoint, params: { ...endpoint.params, url } })
+            }
+            readOnly={disabled}
+          />
+        )}
       </ConfigItem>
       {endpoint.type === "Ntfy" && (
         <ConfigInput
@@ -65,11 +66,157 @@ export default function AlerterConfigEndpoint({
           email
         />
       )}
+      {endpoint.type === "Mqtt" && (
+        <>
+          <ConfigInput
+            label="Broker URL"
+            description="Required. MQTT broker URL, for example mqtt://localhost:1883."
+            placeholder="mqtt://localhost:1883"
+            value={endpoint.params.broker_url}
+            onValueChange={(broker_url) =>
+              set({
+                ...endpoint,
+                params: { ...endpoint.params, broker_url },
+              })
+            }
+            disabled={disabled}
+          />
+          <ConfigInput
+            label="Topic"
+            description="Required. Topic to publish the alert JSON to."
+            placeholder="komodo/events"
+            value={endpoint.params.topic}
+            onValueChange={(topic) =>
+              set({
+                ...endpoint,
+                params: { ...endpoint.params, topic },
+              })
+            }
+            disabled={disabled}
+          />
+          <ConfigInput
+            label="Username"
+            description="Optional broker username."
+            placeholder="username"
+            value={endpoint.params.username ?? ""}
+            onValueChange={(username) =>
+              set({
+                ...endpoint,
+                params: { ...endpoint.params, username: username || undefined },
+              })
+            }
+            disabled={disabled}
+          />
+          <ConfigInput
+            label="Password"
+            description="Optional broker password."
+            placeholder="password"
+            value={endpoint.params.password ?? ""}
+            onValueChange={(password) =>
+              set({
+                ...endpoint,
+                params: { ...endpoint.params, password: password || undefined },
+              })
+            }
+            inputProps={{ type: "password" }}
+            disabled={disabled}
+          />
+          <ConfigInput
+            label="Client ID"
+            description="Optional MQTT client identifier. If empty, Komodo generates one."
+            placeholder="komodo-core"
+            value={endpoint.params.client_id ?? ""}
+            onValueChange={(client_id) =>
+              set({
+                ...endpoint,
+                params: {
+                  ...endpoint.params,
+                  client_id: client_id || undefined,
+                },
+              })
+            }
+            disabled={disabled}
+          />
+          <ConfigItem
+            label="QoS"
+            description="Optional quality of service level."
+          >
+            <Select
+              value={String(endpoint.params.qos ?? 0)}
+              data={[
+                { value: "0", label: "0" },
+                { value: "1", label: "1" },
+                { value: "2", label: "2" },
+              ]}
+              onChange={(qos) =>
+                set({
+                  ...endpoint,
+                  params: {
+                    ...endpoint.params,
+                    qos: Number(qos ?? "0"),
+                  },
+                })
+              }
+              disabled={disabled}
+              w={{ base: "85%", lg: 400 }}
+            />
+          </ConfigItem>
+          <ConfigItem
+            label="Retain"
+            description="Optional retain flag for published messages."
+          >
+            <Select
+              value={(endpoint.params.retain ?? false) ? "true" : "false"}
+              data={[
+                { value: "false", label: "false" },
+                { value: "true", label: "true" },
+              ]}
+              onChange={(retain) =>
+                set({
+                  ...endpoint,
+                  params: {
+                    ...endpoint.params,
+                    retain: retain === "true",
+                  },
+                })
+              }
+              disabled={disabled}
+              w={{ base: "85%", lg: 400 }}
+            />
+          </ConfigItem>
+        </>
+      )}
     </>
   );
 }
 
-function defaultUrl(type: Types.AlerterEndpoint["type"]) {
+function defaultEndpoint(
+  type: Types.AlerterEndpoint["type"],
+): Types.AlerterEndpoint {
+  return type === "Mqtt"
+    ? {
+        type,
+        params: {
+          broker_url: "mqtt://localhost:1883",
+          topic: "komodo/events",
+          username: undefined,
+          password: undefined,
+          client_id: undefined,
+          qos: 0,
+          retain: false,
+        },
+      }
+    : {
+        type,
+        params: {
+          url: defaultUrl(type),
+        },
+      };
+}
+
+function defaultUrl(
+  type: Exclude<Types.AlerterEndpoint["type"], "Mqtt">,
+) {
   return type === "Custom"
     ? "http://localhost:7000"
     : type === "Slack"
@@ -78,7 +225,5 @@ function defaultUrl(type: Types.AlerterEndpoint["type"]) {
         ? "https://discord.com/api/webhooks/XXXXXXXXXXXX/XXXX-XXXXXXXXXX"
         : type === "Ntfy"
           ? "https://ntfy.sh/komodo"
-          : type === "Pushover"
-            ? "https://api.pushover.net/1/messages.json?token=XXXXXXXXXXXXX&user=XXXXXXXXXXXXX"
-            : "";
+          : "https://api.pushover.net/1/messages.json?token=XXXXXXXXXXXXX&user=XXXXXXXXXXXXX";
 }


### PR DESCRIPTION
## Summary

Adds a native MQTT alerter endpoint alongside the existing Discord, Slack, Ntfy, Pushover, and Custom endpoints.

The MQTT endpoint publishes the existing Komodo alert JSON payload unchanged to a configured MQTT broker.

## Configuration

The new endpoint supports:

- Broker URL
- Topic
- Username
- Password
- Client ID
- QoS
- Retain

Default topic:

`komodo/events`

## Testing

Tested in a live Komodo deployment by building Core from this branch, configuring an MQTT alerter, and publishing alerts to Mosquitto.

Confirmed receipt of native alert JSON payloads on MQTT, including BuildFailed alerts.

Example payload:

```json
{
  "ts": 1783366219812,
  "resolved": true,
  "level": "WARNING",
  "target": {
    "type": "Build",
    "id": "6811218440659c0cce2737c5"
  },
  "data": {
    "type": "BuildFailed",
    "data": {
      "id": "6811218440659c0cce2737c5",
      "name": "mylinux",
      "version": {
        "major": 1,
        "minor": 0,
        "patch": 10
      }
    }
  },
  "resolved_ts": 1783366219812
}
```
## Notes

This intentionally does not transform, wrap, or normalize the payload. Consumers can inspect data.type and the existing alert structure directly.