### PR TITLE
setup-periphery.py: add "--core-public-keys" command line argument

### DIFF
--- a/scripts/readme.md
+++ b/scripts/readme.md
@@ -27,6 +27,8 @@ options:
                         https://raw.githubusercontent.com/moghtech/komodo/refs/heads/main/config/periphery.config.toml)
   --binary-url BINARY_URL
                         Use alternate binary source (default: https://github.com/moghtech/komodo/releases/download)
+  --core-public-keys CORE_PUBLIC_KEYS
+                        Comma separate list of accepted public keys to allow Core(s) to connect. May include "file:/..."
 ```
 
 These scripts will set up Komodo Periphery on your hosts, managed by systemd.

--- a/scripts/setup-periphery.py
+++ b/scripts/setup-periphery.py
@@ -64,6 +64,12 @@ def parse_args():
 		help="Use alternate binary source"
 	)
 
+	p.add_argument(
+		"--core-public-keys",
+		default="",
+		help="Trust Komodo Core public keys. Comma separated list of base58 encoded public keys."
+	)
+
 	return p.parse_args()
 
 def load_paths(args):
@@ -143,6 +149,9 @@ def map_config_line(args, home_dir, line):
 	## Handle onboarding key
 	if line.startswith("# onboarding_key =") and args.onboarding_key != None:
 		return f'onboarding_key = "{args.onboarding_key}"'
+	## Handle core public keys
+	if line.startswith("# core_public_keys =") and args.core_public_keys:
+		return f'core_public_keys = "{args.core_public_keys}"'
 	return line
 
 def write_config(args, home_dir, config_dir):
@@ -232,6 +241,7 @@ def main():
 	print(f'bin dir: {bin_dir}')
 	print(f'config dir: {config_dir}')
 	print(f'service file dir: {service_dir}')
+	print(f'core public keys: {args.core_public_keys}')
 
 	download_binary(args, bin_dir)
 	write_config(args, home_dir, config_dir)


### PR DESCRIPTION
Addressed issue https://github.com/moghtech/komodo/issues/1523

Tested this on my setup and the periphery server was registered correctly by the Core.