### PR TITLE
fix: log webhook branch-mismatch skips at debug instead of warn

### DIFF
--- a/bin/core/src/api/listener/mod.rs
+++ b/bin/core/src/api/listener/mod.rs
@@ -1,6 +1,5 @@
 use std::sync::Arc;
 
-use anyhow::anyhow;
 use axum::{Router, http::HeaderMap};
 use komodo_client::entities::resource::Resource;
 use mogh_cache::CloneCache;
@@ -41,12 +40,21 @@ trait VerifySecret {
 /// Implemented on the integration struct, eg [integrations::github::Github]
 trait ExtractBranch {
   fn extract_branch(body: &str) -> anyhow::Result<String>;
-  fn verify_branch(body: &str, expected: &str) -> anyhow::Result<()> {
+  /// Whether the webhook body's branch matches `expected`.
+  /// A mismatch is routine and only logged at debug; errors
+  /// only when the branch cannot be extracted from the body.
+  fn branch_matches(
+    body: &str,
+    expected: &str,
+  ) -> anyhow::Result<bool> {
     let branch = Self::extract_branch(body)?;
     if branch == expected {
-      Ok(())
+      Ok(true)
     } else {
-      Err(anyhow!("request branch does not match expected"))
+      debug!(
+        "Ignoring webhook | push to branch '{branch}' does not match expected branch '{expected}'"
+      );
+      Ok(false)
     }
   }
 }

--- a/bin/core/src/api/listener/resources.rs
+++ b/bin/core/src/api/listener/resources.rs
@@ -57,7 +57,9 @@ pub async fn handle_build_webhook<B: super::ExtractBranch>(
       .branch
   };
 
-  B::verify_branch(&body, &branch)?;
+  if !B::branch_matches(&body, &branch)? {
+    return Ok(());
+  }
 
   // Cancel if currently building
   if action_states()
@@ -265,7 +267,9 @@ async fn handle_repo_webhook_inner<
   let lock = repo_locks().get_or_insert_default(&repo.id).await;
   let _lock = lock.lock().await;
 
-  B::verify_branch(&body, &repo.config.branch)?;
+  if !B::branch_matches(&body, &repo.config.branch)? {
+    return Ok(());
+  }
 
   E::resolve(repo).await
 }
@@ -396,7 +400,9 @@ pub async fn handle_stack_webhook_inner<
       .branch
   };
 
-  B::verify_branch(&body, &branch)?;
+  if !B::branch_matches(&body, &branch)? {
+    return Ok(());
+  }
 
   E::resolve(stack).await.map_err(|e| e.error)
 }
@@ -509,7 +515,9 @@ async fn handle_sync_webhook_inner<
       .branch
   };
 
-  B::verify_branch(&body, &branch)?;
+  if !B::branch_matches(&body, &branch)? {
+    return Ok(());
+  }
 
   E::resolve(sync).await
 }
@@ -546,8 +554,10 @@ pub async fn handle_procedure_webhook<B: super::ExtractBranch>(
     procedure_locks().get_or_insert_default(&procedure.id).await;
   let _lock = lock.lock().await;
 
-  if target_branch != ANY_BRANCH {
-    B::verify_branch(&body, target_branch)?;
+  if target_branch != ANY_BRANCH
+    && !B::branch_matches(&body, target_branch)?
+  {
+    return Ok(());
   }
 
   let user = git_webhook_user().to_owned();
@@ -602,7 +612,10 @@ pub async fn handle_action_webhook<B: super::ExtractBranch>(
   let branch = B::extract_branch(&body)?;
 
   if target_branch != ANY_BRANCH && branch != target_branch {
-    return Err(anyhow!("request branch does not match expected"));
+    debug!(
+      "Ignoring webhook | push to branch '{branch}' does not match expected branch '{target_branch}'"
+    );
+    return Ok(());
   }
 
   let user = git_webhook_user().to_owned();


### PR DESCRIPTION
## Problem

Git providers send push webhooks for **every** branch, and Komodo filters them server side against the branch configured on the resource — exactly as the docs describe (Automate → Webhooks → Branch Filtering). But the skip is implemented as an ordinary error, so it surfaces through the listener's generic failure log:

```
WARN ProcedureWebhook{id="..."}: Failed at running webhook for procedure ... | target branch: main | request branch does not match expected
```

Two problems with that:

- A routine, by-design skip is indistinguishable from a genuine failure (payload parse error, execution error) — same message shape, same WARN level, same log site.
- Any repo with active bot branches makes it noisy. A repo receiving Renovate PRs produces a WARN for every `renovate/*` branch push; on my instance that is **hundreds of warns per day** across two listeners, drowning the warns that matter.

It is also inconsistent with the other by-design skip: `webhook_enabled = false` returns `Ok(())` silently.

## Change

Rename `ExtractBranch::verify_branch` → `branch_matches`, returning `anyhow::Result<bool>`:

- **Branch mismatch** → `Ok(false)`, logged once at `debug!` (`Ignoring webhook | push to branch '...' does not match expected branch '...'`), and the handler returns `Ok(())` — a quiet skip, consistent with the `webhook_enabled` skip. The resource id still lands on the event via the existing `*Webhook{id}` span.
- **Branch extraction failure** (e.g. a ref-less `release`/`workflow_run` payload delivered to a named-branch listener) → still `Err`, still reaching the `Failed at running webhook` WARN. That case is a real misconfiguration signal and keeps its visibility.

The Action handler keeps its inline comparison (it extracts the branch anyway for `WEBHOOK_BRANCH`) with the same debug-and-skip behavior.

No behavior change beyond the log level: executions trigger (and don't trigger) exactly as before.

## Testing

- `cargo check -p komodo_core` clean on this branch.
- `cargo fmt --all -- --check` clean.
- `cargo test`: the 2 failures in `lib/command` (`cancel_kills_process_group`, `timeout_kills_process_group`) are pre-existing on an unpatched checkout of `2.3.0` in my sandbox and unrelated to this change (listener code has no tests).
- Live-traffic sanity check of the current behavior (v2.2.0): confirmed each `renovate/*` push produces the WARN above while a matching `main` push triggers the procedure.
