### PR TITLE
fix(core): remove double offset in GetHistoricalServerStats pagination

### DIFF
--- a/bin/core/src/api/read/server.rs
+++ b/bin/core/src/api/read/server.rs
@@ -353,7 +353,6 @@ impl Resolve<ReadArgs> for GetHistoricalServerStats {
       },
       FindOptions::builder()
         .sort(doc! { "ts": -1 })
-        .skip(page as u64 * STATS_PER_PAGE as u64)
         .limit(STATS_PER_PAGE)
         .build(),
     )


### PR DESCRIPTION
## Related Issue
Closes #1532

## Problem
`GetHistoricalServerStats` applies the `page` offset twice: once when building `ts_vec` (shifting the time window back by `granularity * STATS_PER_PAGE * page`), and again via `.skip(page * STATS_PER_PAGE)` on the MongoDB query. Since the `{ ts: { $in: ts_vec } }` filter already restricts the result to at most `STATS_PER_PAGE` documents for that page, the subsequent `.skip(page * STATS_PER_PAGE)` discards every matched document when `page >= 1`, so every page after the first always returns an empty `stats` array and `next_page` becomes `None`, silently losing all older historical data.

## Change
- `bin/core/src/api/read/server.rs`, `GetHistoricalServerStats::resolve`: removed the `.skip(page * STATS_PER_PAGE)` call from `FindOptions::builder()`. `ts_vec` already encodes the page offset via the time window shift, so the `$in` filter is the correct paging mechanism here — no additional skip is needed.

## Verification
- `cargo check -p komodo_core` passes (no new warnings).
- `cargo fmt -p komodo_core --check` passes.
- Cross-checked against the issue reproduction: `page = 0` behavior is unchanged (`.skip(0)` was already a no-op); `page >= 1` is no longer wiped out by the second offset and now returns the documents matching the `ts_vec` time window, with `next_page` correctly indicating whether an older window has data.
- `bin/core` has no existing unit-test infrastructure and the function depends on a live MongoDB runtime, so no new tests were added; the fix can be verified manually via the issue's `1-min` multi-page reproduction steps.

## Risk
- Change is a single-line removal; does not affect the `page = 0` path. The `ts_vec` construction and `next_page` logic are unchanged. No schema migration, config change, or breaking API change.
- Note: `next_page` is `Some(page + 1)` only when the page returns exactly `STATS_PER_PAGE` records. If a page returns fewer than 200 due to missing data while an older window still has data, `next_page` will be `None` — this is pre-existing behavior, unchanged by this fix, which only removes the double offset that caused the spurious empty results.

## Conventions
- The repository has no explicit `CONTRIBUTING.md` / `CLAUDE.md` / `AGENTS.md` / PR template, so common conventions (Conventional Commits + default PR structure) are used.