### PR TITLE
feat: support cloning repos over ssh

### DIFF
--- a/bin/core/src/api/execute/build.rs
+++ b/bin/core/src/api/execute/build.rs
@@ -46,7 +46,7 @@ use crate::{
   alert::send_alerts,
   api::write::WriteArgs,
   helpers::{
-    build_git_token,
+    build_git_credential,
     builder::{cleanup_builder_instance, connect_builder_periphery},
     channel::build_cancel_channel,
     query::{
@@ -165,8 +165,8 @@ impl Resolve<ExecuteArgs> for RunBuild {
     update.version = build.config.version;
     update_update(update.clone()).await?;
 
-    let git_token =
-      build_git_token(&mut build, repo.as_mut()).await?;
+    let git_credential =
+      build_git_credential(&mut build, repo.as_mut()).await?;
 
     let registry_tokens =
       validate_account_extract_registry_tokens(&build).await?;
@@ -260,7 +260,7 @@ impl Resolve<ExecuteArgs> for RunBuild {
         res = periphery
           .request(api::git::PullOrCloneRepo {
             args: repo.as_ref().map(Into::into).unwrap_or((&build).into()),
-            git_token,
+            git_credential,
             environment: Default::default(),
             env_file_path: Default::default(),
             on_clone: None,

--- a/bin/core/src/api/execute/repo.rs
+++ b/bin/core/src/api/execute/repo.rs
@@ -32,7 +32,7 @@ use crate::{
   helpers::{
     builder::{cleanup_builder_instance, connect_builder_periphery},
     channel::repo_cancel_channel,
-    git_token, periphery_client,
+    git_credential, periphery_client,
     query::{VariablesAndSecrets, get_variables_and_secrets},
     update::update_update,
   },
@@ -118,7 +118,7 @@ impl Resolve<ExecuteArgs> for CloneRepo {
       return Err(anyhow!("repo has no server attached").into());
     }
 
-    let git_token = git_token(
+    let git_credential = git_credential(
       &repo.config.git_provider,
       &repo.config.git_account,
       |https| repo.config.git_https = https,
@@ -141,7 +141,7 @@ impl Resolve<ExecuteArgs> for CloneRepo {
     let logs = match periphery
       .request(api::git::CloneRepo {
         args: (&repo).into(),
-        git_token,
+        git_credential,
         environment: repo.config.env_vars()?,
         env_file_path: repo.config.env_file_path,
         on_clone: repo.config.on_clone.into(),
@@ -263,7 +263,7 @@ impl Resolve<ExecuteArgs> for PullRepo {
       return Err(anyhow!("repo has no server attached").into());
     }
 
-    let git_token = git_token(
+    let git_credential = git_credential(
       &repo.config.git_provider,
       &repo.config.git_account,
       |https| repo.config.git_https = https,
@@ -286,7 +286,7 @@ impl Resolve<ExecuteArgs> for PullRepo {
     let logs = match periphery
       .request(api::git::PullRepo {
         args: (&repo).into(),
-        git_token,
+        git_credential,
         environment: repo.config.env_vars()?,
         env_file_path: repo.config.env_file_path,
         on_pull: repo.config.on_pull.into(),
@@ -452,7 +452,7 @@ impl Resolve<ExecuteArgs> for BuildRepo {
     let mut update = update.clone();
     update_update(update.clone()).await?;
 
-    let git_token = git_token(
+    let git_credential = git_credential(
       &repo.config.git_provider,
       &repo.config.git_account,
       |https| repo.config.git_https = https,
@@ -545,7 +545,7 @@ impl Resolve<ExecuteArgs> for BuildRepo {
       res = periphery
         .request(api::git::CloneRepo {
           args: (&repo).into(),
-          git_token,
+          git_credential,
           environment: repo.config.env_vars()?,
           env_file_path: repo.config.env_file_path,
           on_clone: repo.config.on_clone.into(),

--- a/bin/core/src/api/execute/stack.rs
+++ b/bin/core/src/api/execute/stack.rs
@@ -33,7 +33,7 @@ use crate::{
   helpers::{
     periphery_client,
     query::{VariablesAndSecrets, get_variables_and_secrets},
-    stack_git_token,
+    stack_git_credential,
     swarm::swarm_request,
     update::{
       add_update_without_send, init_execution_update, update_update,
@@ -153,8 +153,8 @@ impl Resolve<ExecuteArgs> for DeployStack {
       ))
     }
 
-    let git_token =
-      stack_git_token(&mut stack, repo.as_mut()).await?;
+    let git_credential =
+      stack_git_credential(&mut stack, repo.as_mut()).await?;
 
     let registry_token = crate::helpers::registry_token(
       &stack.config.registry_provider,
@@ -203,7 +203,7 @@ impl Resolve<ExecuteArgs> for DeployStack {
           DeploySwarmStack {
             stack: stack.clone(),
             repo,
-            git_token,
+            git_credential,
             registry_token,
             replacers: secret_replacers.into_iter().collect(),
           },
@@ -217,7 +217,7 @@ impl Resolve<ExecuteArgs> for DeployStack {
             stack: stack.clone(),
             services: self.services,
             repo,
-            git_token,
+            git_credential,
             registry_token,
             replacers: secret_replacers.into_iter().collect(),
           })
@@ -858,7 +858,8 @@ pub async fn pull_stack_inner(
     ))
   }
 
-  let git_token = stack_git_token(&mut stack, repo.as_mut()).await?;
+  let git_credential =
+    stack_git_credential(&mut stack, repo.as_mut()).await?;
 
   let registry_token = crate::helpers::registry_token(
       &stack.config.registry_provider,
@@ -895,7 +896,7 @@ pub async fn pull_stack_inner(
       stack,
       services,
       repo,
-      git_token,
+      git_credential,
       registry_token,
       replacers: secret_replacers.into_iter().collect(),
     })
@@ -1349,8 +1350,8 @@ impl Resolve<ExecuteArgs> for RunStackService {
     let mut update = update.clone();
     update_update(update.clone()).await?;
 
-    let git_token =
-      stack_git_token(&mut stack, repo.as_mut()).await?;
+    let git_credential =
+      stack_git_credential(&mut stack, repo.as_mut()).await?;
 
     let registry_token = crate::helpers::registry_token(
       &stack.config.registry_provider,
@@ -1384,7 +1385,7 @@ impl Resolve<ExecuteArgs> for RunStackService {
       .request(ComposeRun {
         stack,
         repo,
-        git_token,
+        git_credential,
         registry_token,
         replacers: secret_replacers.into_iter().collect(),
         service: self.service,

--- a/bin/core/src/api/write/build.rs
+++ b/bin/core/src/api/write/build.rs
@@ -26,7 +26,7 @@ use crate::helpers::builder::connect_builder_periphery;
 use crate::{
   config::core_config,
   helpers::{
-    git_token,
+    git_credential,
     update::{add_update, make_update},
   },
   periphery::PeripheryClient,
@@ -263,7 +263,7 @@ async fn write_dockerfile_contents_git(
   }
 
   let access_token = if let Some(account) = &repo_args.account {
-    git_token(&repo_args.provider, account, |https| repo_args.https = https)
+    git_credential(&repo_args.provider, account, |https| repo_args.https = https)
     .await
     .with_context(
       || format!("Failed to get git token in call to db. Stopping run. | {} | {account}", repo_args.provider),
@@ -278,7 +278,7 @@ async fn write_dockerfile_contents_git(
     git::init_folder_as_repo(
       &root,
       &repo_args,
-      access_token.as_deref(),
+      access_token.as_ref(),
       &mut update.logs,
     )
     .await;
@@ -511,7 +511,7 @@ async fn get_git_remote(
   clone_args.destination = Some(repo_path.display().to_string());
 
   let access_token = if let Some(username) = &clone_args.account {
-    git_token(&clone_args.provider, username, |https| {
+    git_credential(&clone_args.provider, username, |https| {
           clone_args.https = https
         })
         .await

--- a/bin/core/src/api/write/repo.rs
+++ b/bin/core/src/api/write/repo.rs
@@ -21,7 +21,7 @@ use periphery_client::api;
 use crate::{
   config::core_config,
   helpers::{
-    git_token, periphery_client,
+    git_credential, periphery_client,
     update::{add_update, make_update},
   },
   permission::get_check_permissions,
@@ -222,7 +222,7 @@ impl Resolve<WriteArgs> for RefreshRepoCache {
     clone_args.destination = Some(repo_path.display().to_string());
 
     let access_token = if let Some(username) = &clone_args.account {
-      git_token(&clone_args.provider, username, |https| {
+      git_credential(&clone_args.provider, username, |https| {
           clone_args.https = https
         })
         .await

--- a/bin/core/src/api/write/stack.rs
+++ b/bin/core/src/api/write/stack.rs
@@ -38,7 +38,7 @@ use crate::{
   config::core_config,
   helpers::{
     query::{get_all_tags, get_swarm_or_server},
-    stack_git_token, swarm_or_server_request,
+    stack_git_credential, swarm_or_server_request,
     update::{add_update, make_update, poll_update_until_complete},
   },
   permission::get_check_permissions,
@@ -331,7 +331,8 @@ async fn write_stack_file_contents_git(
   } else {
     None
   };
-  let git_token = stack_git_token(&mut stack, repo.as_mut()).await?;
+  let git_credential =
+    stack_git_credential(&mut stack, repo.as_mut()).await?;
 
   let mut repo_args: RepoExecutionArgs = if let Some(repo) = &repo {
     repo.into()
@@ -364,7 +365,7 @@ async fn write_stack_file_contents_git(
     git::init_folder_as_repo(
       &root,
       &repo_args,
-      git_token.as_deref(),
+      git_credential.as_ref(),
       &mut update.logs,
     )
     .await;
@@ -382,7 +383,7 @@ async fn write_stack_file_contents_git(
   match git::pull_or_clone(
     repo_args,
     &core_config().repo_directory,
-    git_token,
+    git_credential,
   )
   .await
   .context("Failed to pull latest changes before commit")

--- a/bin/core/src/api/write/sync.rs
+++ b/bin/core/src/api/write/sync.rs
@@ -42,7 +42,7 @@ use crate::{
   config::core_config,
   helpers::{
     all_resources::AllResourcesById,
-    git_token,
+    git_credential,
     query::get_id_to_tags,
     update::{add_update, make_update, update_update},
   },
@@ -315,8 +315,8 @@ async fn write_sync_file_contents_git(
   let root = repo_args.unique_path(&core_config().repo_directory)?;
   repo_args.destination = Some(root.display().to_string());
 
-  let git_token = if let Some(account) = &repo_args.account {
-    git_token(&repo_args.provider, account, |https| repo_args.https = https)
+  let git_credential = if let Some(account) = &repo_args.account {
+    git_credential(&repo_args.provider, account, |https| repo_args.https = https)
     .await
     .with_context(
       || format!("Failed to get git token in call to db. Stopping run. | {} | {account}", repo_args.provider),
@@ -353,7 +353,7 @@ async fn write_sync_file_contents_git(
     git::init_folder_as_repo(
       &root,
       &repo_args,
-      git_token.as_deref(),
+      git_credential.as_ref(),
       &mut update.logs,
     )
     .await;
@@ -371,7 +371,7 @@ async fn write_sync_file_contents_git(
   match git::pull_or_clone(
     repo_args,
     &core_config().repo_directory,
-    git_token,
+    git_credential,
   )
   .await
   .context("Failed to pull latest changes before commit")
@@ -657,7 +657,7 @@ async fn commit_git_sync(
   args.destination = Some(root.display().to_string());
 
   let access_token = if let Some(account) = &args.account {
-    git_token(&args.provider, account, |https| args.https = https)
+    git_credential(&args.provider, account, |https| args.https = https)
       .await
       .with_context(
         || format!("Failed to get git token in call to db. Stopping run. | {} | {account}", args.provider),

--- a/bin/core/src/helpers/mod.rs
+++ b/bin/core/src/helpers/mod.rs
@@ -6,7 +6,7 @@ use database::mungos::mongodb::bson::{Bson, doc};
 use indexmap::IndexSet;
 use komodo_client::entities::SwarmOrServer;
 use komodo_client::entities::{
-  ResourceTarget,
+  GitCredential, ResourceTarget,
   build::Build,
   permission::{
     Permission, PermissionLevel, SpecificPermission, UserTarget,
@@ -53,14 +53,18 @@ pub fn empty_or_only_spaces(word: &str) -> bool {
   true
 }
 
-/// First checks db for token, then checks core config.
+fn non_empty(field: &str) -> Option<String> {
+  (!field.is_empty()).then(|| field.to_string())
+}
+
+/// First checks db for the account, then checks core config.
 /// Only errors if db call errors.
-/// Returns (token, use_https)
-pub async fn git_token(
+/// Returns the account's token and/or ssh key, if either is set.
+pub async fn git_credential(
   provider_domain: &str,
   account_username: &str,
   mut on_https_found: impl FnMut(bool),
-) -> anyhow::Result<Option<String>> {
+) -> anyhow::Result<Option<GitCredential>> {
   if provider_domain.is_empty() || account_username.is_empty() {
     return Ok(None);
   }
@@ -71,7 +75,10 @@ pub async fn git_token(
     .context("failed to query db for git provider accounts")?;
   if let Some(provider) = db_provider {
     on_https_found(provider.https);
-    return Ok(Some(provider.token));
+    return Ok(Some(GitCredential {
+      token: non_empty(&provider.token),
+      ssh_key: non_empty(&provider.ssh_key),
+    }));
   }
   Ok(
     core_config()
@@ -84,17 +91,21 @@ pub async fn git_token(
           .accounts
           .iter()
           .find(|account| account.username == account_username)
-          .map(|account| account.token.clone())
-      }),
+          .map(|account| GitCredential {
+            token: non_empty(&account.token),
+            ssh_key: non_empty(&account.ssh_key),
+          })
+      })
+      .filter(|credential| !credential.is_empty()),
   )
 }
 
-pub async fn stack_git_token(
+pub async fn stack_git_credential(
   stack: &mut Stack,
   repo: Option<&mut Repo>,
-) -> anyhow::Result<Option<String>> {
+) -> anyhow::Result<Option<GitCredential>> {
   if let Some(repo) = repo {
-    return git_token(
+    return git_credential(
       &repo.config.git_provider,
       &repo.config.git_account,
       |https| repo.config.git_https = https,
@@ -102,12 +113,12 @@ pub async fn stack_git_token(
     .await
     .with_context(|| {
       format!(
-        "Failed to get git token. Stopping run. | {} | {}",
+        "Failed to get git credential. Stopping run. | {} | {}",
         repo.config.git_provider, repo.config.git_account
       )
     });
   }
-  git_token(
+  git_credential(
     &stack.config.git_provider,
     &stack.config.git_account,
     |https| stack.config.git_https = https,
@@ -115,18 +126,18 @@ pub async fn stack_git_token(
   .await
   .with_context(|| {
     format!(
-      "Failed to get git token. Stopping run. | {} | {}",
+      "Failed to get git credential. Stopping run. | {} | {}",
       stack.config.git_provider, stack.config.git_account
     )
   })
 }
 
-pub async fn build_git_token(
+pub async fn build_git_credential(
   build: &mut Build,
   repo: Option<&mut Repo>,
-) -> anyhow::Result<Option<String>> {
+) -> anyhow::Result<Option<GitCredential>> {
   if let Some(repo) = repo {
-    return git_token(
+    return git_credential(
       &repo.config.git_provider,
       &repo.config.git_account,
       |https| repo.config.git_https = https,
@@ -134,12 +145,12 @@ pub async fn build_git_token(
     .await
     .with_context(|| {
       format!(
-        "Failed to get git token. Stopping run. | {} | {}",
+        "Failed to get git credential. Stopping run. | {} | {}",
         repo.config.git_provider, repo.config.git_account
       )
     });
   }
-  git_token(
+  git_credential(
     &build.config.git_provider,
     &build.config.git_account,
     |https| build.config.git_https = https,
@@ -147,7 +158,7 @@ pub async fn build_git_token(
   .await
   .with_context(|| {
     format!(
-      "Failed to get git token. Stopping run. | {} | {}",
+      "Failed to get git credential. Stopping run. | {} | {}",
       build.config.git_provider, build.config.git_account
     )
   })

--- a/bin/core/src/stack/remote.rs
+++ b/bin/core/src/stack/remote.rs
@@ -9,7 +9,7 @@ use komodo_client::entities::{
   update::Log,
 };
 
-use crate::{config::core_config, helpers::git_token};
+use crate::{config::core_config, helpers::git_credential};
 
 #[derive(Default)]
 pub struct RemoteComposeContents {
@@ -93,7 +93,7 @@ pub async fn ensure_remote_repo(
   let config = core_config();
 
   let access_token = if let Some(username) = &clone_args.account {
-    git_token(&clone_args.provider, username, |https| {
+    git_credential(&clone_args.provider, username, |https| {
         clone_args.https = https
       })
       .await

--- a/bin/core/src/sync/remote.rs
+++ b/bin/core/src/sync/remote.rs
@@ -8,7 +8,7 @@ use komodo_client::entities::{
   update::Log,
 };
 
-use crate::{config::core_config, helpers::git_token};
+use crate::{config::core_config, helpers::git_credential};
 
 use super::file::extend_resources;
 
@@ -68,7 +68,7 @@ async fn get_repo(
   mut clone_args: RepoExecutionArgs,
 ) -> anyhow::Result<RemoteResources> {
   let access_token = if let Some(account) = &clone_args.account {
-    git_token(&clone_args.provider, account, |https| clone_args.https = https)
+    git_credential(&clone_args.provider, account, |https| clone_args.https = https)
       .await
       .with_context(
         || format!("Failed to get git token in call to db. Stopping run. | {} | {account}", clone_args.provider),

--- a/bin/periphery/src/api/compose.rs
+++ b/bin/periphery/src/api/compose.rs
@@ -232,12 +232,16 @@ impl Resolve<crate::api::Args> for WriteCommitComposeContents {
       username,
       file_path,
       contents,
-      git_token,
+      git_credential,
     } = self;
 
-    let root =
-      pull_or_clone_stack(&stack, repo.as_ref(), git_token, args)
-        .await?;
+    let root = pull_or_clone_stack(
+      &stack,
+      repo.as_ref(),
+      git_credential,
+      args,
+    )
+    .await?;
 
     let file_path = stack
       .config
@@ -284,7 +288,7 @@ impl Resolve<crate::api::Args> for ComposePull {
       mut stack,
       repo,
       services,
-      git_token,
+      git_credential,
       registry_token,
       mut replacers,
     } = self;
@@ -303,7 +307,7 @@ impl Resolve<crate::api::Args> for ComposePull {
     let (run_directory, env_file_path) = match write_stack(
       &stack,
       repo.as_ref(),
-      git_token,
+      git_credential,
       replacers.clone(),
       &mut res,
       args,
@@ -445,7 +449,7 @@ impl Resolve<crate::api::Args> for ComposeUp {
       mut stack,
       repo,
       services,
-      git_token,
+      git_credential,
       registry_token,
       mut replacers,
     } = self;
@@ -464,7 +468,7 @@ impl Resolve<crate::api::Args> for ComposeUp {
     let (run_directory, env_file_path) = match write_stack(
       &stack,
       repo.as_ref(),
-      git_token,
+      git_credential,
       replacers.clone(),
       &mut res,
       args,
@@ -832,7 +836,7 @@ impl Resolve<crate::api::Args> for ComposeRun {
     let ComposeRun {
       mut stack,
       repo,
-      git_token,
+      git_credential,
       registry_token,
       mut replacers,
       service,
@@ -859,7 +863,7 @@ impl Resolve<crate::api::Args> for ComposeRun {
     let (run_directory, env_file_path) = match write_stack(
       &stack,
       repo.as_ref(),
-      git_token,
+      git_credential,
       replacers.clone(),
       &mut res,
       args,

--- a/bin/periphery/src/api/git.rs
+++ b/bin/periphery/src/api/git.rs
@@ -50,7 +50,7 @@ impl Resolve<crate::api::Args> for CloneRepo {
   ) -> anyhow::Result<PeripheryRepoExecutionResponse> {
     let CloneRepo {
       args,
-      git_token,
+      git_credential,
       environment,
       env_file_path,
       on_clone,
@@ -59,7 +59,8 @@ impl Resolve<crate::api::Args> for CloneRepo {
       replacers,
     } = self;
 
-    let token = crate::helpers::git_token(git_token, &args)?;
+    let token =
+      crate::helpers::git_credential(git_credential, &args)?;
     let root_repo_dir = default_folder(args.default_folder)?;
 
     let res = git::clone(args, &root_repo_dir, token).await?;
@@ -96,7 +97,7 @@ impl Resolve<crate::api::Args> for PullRepo {
   ) -> anyhow::Result<PeripheryRepoExecutionResponse> {
     let PullRepo {
       args,
-      git_token,
+      git_credential,
       environment,
       env_file_path,
       on_pull,
@@ -104,7 +105,8 @@ impl Resolve<crate::api::Args> for PullRepo {
       replacers,
     } = self;
 
-    let token = crate::helpers::git_token(git_token, &args)?;
+    let token =
+      crate::helpers::git_credential(git_credential, &args)?;
     let parent_dir = default_folder(args.default_folder)?;
 
     let res = git::pull(args, &parent_dir, token).await?;
@@ -141,7 +143,7 @@ impl Resolve<crate::api::Args> for PullOrCloneRepo {
   ) -> anyhow::Result<PeripheryRepoExecutionResponse> {
     let PullOrCloneRepo {
       args,
-      git_token,
+      git_credential,
       environment,
       env_file_path,
       on_clone,
@@ -150,7 +152,8 @@ impl Resolve<crate::api::Args> for PullOrCloneRepo {
       replacers,
     } = self;
 
-    let token = crate::helpers::git_token(git_token, &args)?;
+    let token =
+      crate::helpers::git_credential(git_credential, &args)?;
     let parent_dir = default_folder(args.default_folder)?;
 
     let (res, cloned) =

--- a/bin/periphery/src/api/swarm/stack.rs
+++ b/bin/periphery/src/api/swarm/stack.rs
@@ -127,7 +127,7 @@ impl Resolve<crate::api::Args> for DeploySwarmStack {
     let DeploySwarmStack {
       mut stack,
       repo,
-      git_token,
+      git_credential,
       registry_token,
       mut replacers,
     } = self;
@@ -147,7 +147,7 @@ impl Resolve<crate::api::Args> for DeploySwarmStack {
     let (run_directory, env_file_path) = match write_stack(
       &stack,
       repo.as_ref(),
-      git_token,
+      git_credential,
       replacers.clone(),
       &mut res,
       args,

--- a/bin/periphery/src/helpers.rs
+++ b/bin/periphery/src/helpers.rs
@@ -12,9 +12,9 @@ use environment::write_env_file;
 use interpolate::Interpolator;
 use komodo_client::{
   entities::{
-    EnvironmentVar, RepoExecutionArgs, RepoExecutionResponse,
-    SearchCombinator, SystemCommand, all_logs_success,
-    deployment::Conversion,
+    EnvironmentVar, GitCredential, RepoExecutionArgs,
+    RepoExecutionResponse, SearchCombinator, SystemCommand,
+    all_logs_success, deployment::Conversion,
   },
   parsers::QUOTE_PATTERN,
 };
@@ -242,32 +242,34 @@ pub async fn handle_post_repo_execution(
 //  Token
 // =======
 
-pub fn git_token_simple(
+pub fn git_credential_simple(
   domain: &str,
   account_username: &str,
-) -> anyhow::Result<&'static str> {
+) -> anyhow::Result<GitCredential> {
   periphery_config()
     .git_providers
     .iter()
     .find(|provider| provider.domain == domain)
     .and_then(|provider| {
-      provider.accounts.iter().find(|account| account.username == account_username).map(|account| account.token.as_str())
+      provider.accounts.iter().find(|account| account.username == account_username).map(|account| GitCredential {
+        token: (!account.token.is_empty()).then(|| account.token.clone()),
+        ssh_key: (!account.ssh_key.is_empty()).then(|| account.ssh_key.clone()),
+      })
     })
-    .with_context(|| format!("Did not find token in config for git account {account_username} | domain {domain}"))
+    .with_context(|| format!("Did not find credential in config for git account {account_username} | domain {domain}"))
 }
 
-pub fn git_token(
-  core_token: Option<String>,
+pub fn git_credential(
+  core_credential: Option<GitCredential>,
   args: &RepoExecutionArgs,
-) -> anyhow::Result<Option<String>> {
-  if core_token.is_some() {
-    return Ok(core_token);
+) -> anyhow::Result<Option<GitCredential>> {
+  if core_credential.is_some() {
+    return Ok(core_credential);
   }
   let Some(account) = &args.account else {
     return Ok(None);
   };
-  let token = git_token_simple(&args.provider, account)?;
-  Ok(Some(token.to_string()))
+  Ok(Some(git_credential_simple(&args.provider, account)?))
 }
 
 pub fn registry_token(

--- a/bin/periphery/src/stack/mod.rs
+++ b/bin/periphery/src/stack/mod.rs
@@ -5,7 +5,7 @@ use std::path::{Path, PathBuf};
 use anyhow::{Context as _, anyhow};
 use formatting::format_serror;
 use komodo_client::entities::{
-  FileContents, RepoExecutionArgs,
+  FileContents, GitCredential, RepoExecutionArgs,
   repo::Repo,
   stack::{Stack, StackRemoteFileContents},
   to_path_compatible_name,
@@ -75,7 +75,7 @@ pub async fn maybe_login_registry(
 pub async fn pull_or_clone_stack(
   stack: &Stack,
   repo: Option<&Repo>,
-  git_token: Option<String>,
+  git_credential: Option<GitCredential>,
   req_args: &Args,
 ) -> anyhow::Result<PathBuf> {
   if stack.config.files_on_host {
@@ -108,11 +108,12 @@ pub async fn pull_or_clone_stack(
   };
   args.destination = Some(root.display().to_string());
 
-  let git_token = crate::helpers::git_token(git_token, &args)?;
+  let git_credential =
+    crate::helpers::git_credential(git_credential, &args)?;
 
   PullOrCloneRepo {
     args,
-    git_token,
+    git_credential,
     // All the extra pull functions
     // (env, on clone, on pull)
     // are disabled with this method.

--- a/bin/periphery/src/stack/write.rs
+++ b/bin/periphery/src/stack/write.rs
@@ -3,8 +3,8 @@ use std::path::PathBuf;
 use anyhow::{Context, anyhow};
 use formatting::format_serror;
 use komodo_client::entities::{
-  FileContents, RepoExecutionArgs, all_logs_success, repo::Repo,
-  stack::Stack, to_path_compatible_name, update::Log,
+  FileContents, GitCredential, RepoExecutionArgs, all_logs_success,
+  repo::Repo, stack::Stack, to_path_compatible_name, update::Log,
 };
 use mogh_resolver::Resolve;
 use periphery_client::api::{
@@ -64,7 +64,7 @@ impl WriteStackRes for &mut ComposeRunResponse {
 pub async fn write_stack<'a>(
   stack: &'a Stack,
   repo: Option<&Repo>,
-  git_token: Option<String>,
+  git_credential: Option<GitCredential>,
   replacers: Vec<(String, String)>,
   res: impl WriteStackRes,
   req_args: &Args,
@@ -78,11 +78,17 @@ pub async fn write_stack<'a>(
     write_stack_files_on_host(stack, res).await
   } else if let Some(repo) = repo {
     write_stack_linked_repo(
-      stack, repo, git_token, replacers, res, req_args,
+      stack,
+      repo,
+      git_credential,
+      replacers,
+      res,
+      req_args,
     )
     .await
   } else if !stack.config.repo.is_empty() {
-    write_stack_inline_repo(stack, git_token, res, req_args).await
+    write_stack_inline_repo(stack, git_credential, res, req_args)
+      .await
   } else {
     write_stack_ui_defined(stack, res).await
   }
@@ -129,7 +135,7 @@ async fn write_stack_files_on_host(
 async fn write_stack_linked_repo<'a>(
   stack: &'a Stack,
   repo: &Repo,
-  git_token: Option<String>,
+  git_credential: Option<GitCredential>,
   replacers: Vec<(String, String)>,
   mut res: impl WriteStackRes,
   req_args: &Args,
@@ -150,7 +156,8 @@ async fn write_stack_linked_repo<'a>(
   // Set the clone destination to the one created for this run
   args.destination = Some(root.display().to_string());
 
-  let git_token = stack_git_token(git_token, &args, &mut res)?;
+  let git_credential =
+    stack_git_credential(git_credential, &args, &mut res)?;
 
   let env_file_path = root
     .join(&repo.config.env_file_path)
@@ -167,7 +174,7 @@ async fn write_stack_linked_repo<'a>(
   let clone_res = if stack.config.reclone {
     CloneRepo {
       args,
-      git_token,
+      git_credential,
       environment: repo.config.env_vars()?,
       env_file_path,
       on_clone,
@@ -180,7 +187,7 @@ async fn write_stack_linked_repo<'a>(
   } else {
     PullOrCloneRepo {
       args,
-      git_token,
+      git_credential,
       environment: repo.config.env_vars()?,
       env_file_path,
       on_clone,
@@ -227,7 +234,7 @@ async fn write_stack_linked_repo<'a>(
 #[instrument("WriteStackInlineRepo", skip_all)]
 async fn write_stack_inline_repo<'a>(
   stack: &'a Stack,
-  git_token: Option<String>,
+  git_credential: Option<GitCredential>,
   mut res: impl WriteStackRes,
   req_args: &Args,
 ) -> anyhow::Result<(
@@ -247,12 +254,13 @@ async fn write_stack_inline_repo<'a>(
   // Set the clone destination to the one created for this run
   args.destination = Some(root.display().to_string());
 
-  let git_token = stack_git_token(git_token, &args, &mut res)?;
+  let git_credential =
+    stack_git_credential(git_credential, &args, &mut res)?;
 
   let clone_res = if stack.config.reclone {
     CloneRepo {
       args,
-      git_token,
+      git_credential,
       environment: Default::default(),
       env_file_path: Default::default(),
       on_clone: Default::default(),
@@ -265,7 +273,7 @@ async fn write_stack_inline_repo<'a>(
   } else {
     PullOrCloneRepo {
       args,
-      git_token,
+      git_credential,
       environment: Default::default(),
       env_file_path: Default::default(),
       on_clone: Default::default(),
@@ -378,20 +386,20 @@ async fn write_stack_ui_defined(
   ))
 }
 
-fn stack_git_token<R: WriteStackRes>(
-  core_token: Option<String>,
+fn stack_git_credential<R: WriteStackRes>(
+  core_credential: Option<GitCredential>,
   args: &RepoExecutionArgs,
   res: &mut R,
-) -> anyhow::Result<Option<String>> {
-  helpers::git_token(core_token, args).map_err(|e| {
+) -> anyhow::Result<Option<GitCredential>> {
+  helpers::git_credential(core_credential, args).map_err(|e| {
     let error = format_serror(&e.into());
     res
       .logs()
-      .push(Log::error("Missing git token", error.clone()));
+      .push(Log::error("Missing git credential", error.clone()));
     res.add_remote_error(FileContents {
       path: Default::default(),
       contents: error,
     });
-    anyhow!("failed to find required git token, stopping run")
+    anyhow!("failed to find required git credential, stopping run")
   })
 }

--- a/client/core/rs/src/entities/build.rs
+++ b/client/core/rs/src/entities/build.rs
@@ -398,11 +398,20 @@ pub struct BuildConfig {
 
   /// Whether to use https to clone the repo (versus http). Default: true
   ///
-  /// Note. Komodo does not currently support cloning repos via ssh.
+  /// Ignored if `git_ssh` is enabled.
   #[serde(default = "default_git_https")]
   #[builder(default = "default_git_https()")]
   #[partial_default(default_git_https())]
   pub git_https: bool,
+
+  /// Clone over ssh (`git@{git_provider}:{repo}`) instead of http(s).
+  ///
+  /// The ssh key is provided by the host running the clone,
+  /// via its ssh config / agent - Komodo does not manage keys.
+  /// `git_account` is not used in this mode.
+  #[serde(default)]
+  #[builder(default)]
+  pub git_ssh: bool,
 
   /// The git account used to access private repos.
   /// Passing empty string can only clone public repos.
@@ -615,6 +624,7 @@ impl Default for BuildConfig {
       linked_repo: Default::default(),
       git_provider: default_git_provider(),
       git_https: default_git_https(),
+      git_ssh: false,
       repo: Default::default(),
       branch: default_branch(),
       commit: Default::default(),

--- a/client/core/rs/src/entities/config/mod.rs
+++ b/client/core/rs/src/entities/config/mod.rs
@@ -189,9 +189,14 @@ pub struct ProviderAccount {
   /// The account username. Required.
   #[serde(alias = "account")]
   pub username: String,
-  /// The account access token. Required.
+  /// The account access token. Required for http(s) clones.
   #[serde(default, skip_serializing)]
   pub token: String,
+  /// An ssh private key, used for repos cloned over ssh.
+  ///
+  /// Leave empty to use the ssh config of the host running the clone.
+  #[serde(default, skip_serializing)]
+  pub ssh_key: String,
 }
 
 pub fn empty_or_redacted(src: &str) -> String {

--- a/client/core/rs/src/entities/config/periphery.rs
+++ b/client/core/rs/src/entities/config/periphery.rs
@@ -562,6 +562,7 @@ impl PeripheryConfig {
             .map(|account| ProviderAccount {
               username: account.username.clone(),
               token: empty_or_redacted(&account.token),
+              ssh_key: empty_or_redacted(&account.ssh_key),
             })
             .collect(),
         })
@@ -578,6 +579,7 @@ impl PeripheryConfig {
             .map(|account| ProviderAccount {
               username: account.username.clone(),
               token: empty_or_redacted(&account.token),
+              ssh_key: empty_or_redacted(&account.ssh_key),
             })
             .collect(),
         })

--- a/client/core/rs/src/entities/mod.rs
+++ b/client/core/rs/src/entities/mod.rs
@@ -586,6 +586,39 @@ pub enum DefaultRepoFolder {
   NotApplicable,
 }
 
+/// A credential used to access a private git repo.
+///
+/// Both fields may be set - the token is used for http(s) remotes,
+/// and the ssh key for ssh remotes (see `RepoExecutionArgs::ssh`).
+#[typeshare]
+#[derive(
+  Serialize, Deserialize, Clone, Debug, Default, PartialEq, Eq,
+)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
+pub struct GitCredential {
+  /// `username:token`, or a bare token. Embedded in the https remote url.
+  #[serde(default, skip_serializing_if = "Option::is_none")]
+  pub token: Option<String>,
+  /// A private key in PEM form. Written to a temporary file with mode
+  /// 0600 for the duration of the git command, and passed to git via
+  /// `core.sshCommand`.
+  #[serde(default, skip_serializing_if = "Option::is_none")]
+  pub ssh_key: Option<String>,
+}
+
+impl GitCredential {
+  pub fn token(token: impl Into<String>) -> Self {
+    GitCredential {
+      token: Some(token.into()),
+      ssh_key: None,
+    }
+  }
+
+  pub fn is_empty(&self) -> bool {
+    self.token.is_none() && self.ssh_key.is_none()
+  }
+}
+
 #[typeshare]
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
@@ -596,6 +629,10 @@ pub struct RepoExecutionArgs {
   pub provider: String,
   /// Use https (vs http).
   pub https: bool,
+  /// Clone over ssh (`git@{provider}:{repo}`) instead of http(s).
+  /// Key handling is left to the host's ssh config / agent.
+  #[serde(default)]
+  pub ssh: bool,
   /// Configure the account used to access repo (if private)
   pub account: Option<String>,
   /// Full repo identifier. {namespace}/{repo_name}
@@ -626,9 +663,18 @@ impl RepoExecutionArgs {
 
   pub fn remote_url(
     &self,
-    access_token: Option<&str>,
+    credential: Option<&GitCredential>,
   ) -> anyhow::Result<String> {
-    let access_token_at = match access_token {
+    let repo = self
+      .repo
+      .as_ref()
+      .context("resource has no repo attached")?;
+    if self.ssh {
+      return Ok(format!("git@{}:{repo}", self.provider));
+    }
+    let access_token_at = match credential
+      .and_then(|credential| credential.token.as_deref())
+    {
       Some(token) => match token.split_once(':') {
         Some((username, token)) => format!(
           "{}:{}@",
@@ -642,10 +688,6 @@ impl RepoExecutionArgs {
       None => String::new(),
     };
     let protocol = if self.https { "https" } else { "http" };
-    let repo = self
-      .repo
-      .as_ref()
-      .context("resource has no repo attached")?;
     Ok(format!(
       "{protocol}://{access_token_at}{}/{repo}",
       self.provider
@@ -678,6 +720,7 @@ impl From<&self::stack::Stack> for RepoExecutionArgs {
       provider: optional_string(&stack.config.git_provider)
         .unwrap_or_else(|| String::from("github.com")),
       https: stack.config.git_https,
+      ssh: stack.config.git_ssh,
       account: optional_string(&stack.config.git_account),
       repo: optional_string(&stack.config.repo),
       branch: optional_string(&stack.config.branch)
@@ -696,6 +739,7 @@ impl From<&self::build::Build> for RepoExecutionArgs {
       provider: optional_string(&build.config.git_provider)
         .unwrap_or_else(|| String::from("github.com")),
       https: build.config.git_https,
+      ssh: build.config.git_ssh,
       account: optional_string(&build.config.git_account),
       repo: optional_string(&build.config.repo),
       branch: optional_string(&build.config.branch)
@@ -714,6 +758,7 @@ impl From<&self::repo::Repo> for RepoExecutionArgs {
       provider: optional_string(&repo.config.git_provider)
         .unwrap_or_else(|| String::from("github.com")),
       https: repo.config.git_https,
+      ssh: repo.config.git_ssh,
       account: optional_string(&repo.config.git_account),
       repo: optional_string(&repo.config.repo),
       branch: optional_string(&repo.config.branch)
@@ -732,6 +777,7 @@ impl From<&self::sync::ResourceSync> for RepoExecutionArgs {
       provider: optional_string(&sync.config.git_provider)
         .unwrap_or_else(|| String::from("github.com")),
       https: sync.config.git_https,
+      ssh: sync.config.git_ssh,
       account: optional_string(&sync.config.git_account),
       repo: optional_string(&sync.config.repo),
       branch: optional_string(&sync.config.branch)
@@ -1735,5 +1781,41 @@ impl SwarmOrServer {
       return None;
     };
     Some(&server.name)
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::{DefaultRepoFolder, GitCredential, RepoExecutionArgs};
+
+  fn args(ssh: bool) -> RepoExecutionArgs {
+    RepoExecutionArgs {
+      name: String::from("test"),
+      provider: String::from("github.com"),
+      https: true,
+      ssh,
+      account: Some(String::from("my-user")),
+      repo: Some(String::from("moghtech/komodo")),
+      branch: String::from("main"),
+      commit: None,
+      destination: None,
+      default_folder: DefaultRepoFolder::Repos,
+    }
+  }
+
+  #[test]
+  fn remote_url_https_embeds_token() {
+    let url = args(false)
+      .remote_url(Some(&GitCredential::token("my-user:tok")))
+      .unwrap();
+    assert_eq!(url, "https://my-user:tok@github.com/moghtech/komodo");
+  }
+
+  #[test]
+  fn remote_url_ssh_omits_token() {
+    let url = args(true)
+      .remote_url(Some(&GitCredential::token("my-user:tok")))
+      .unwrap();
+    assert_eq!(url, "git@github.com:moghtech/komodo");
   }
 }

--- a/client/core/rs/src/entities/provider.rs
+++ b/client/core/rs/src/entities/provider.rs
@@ -51,6 +51,12 @@ pub struct GitProviderAccount {
   /// If the database / host can be accessed this is insecure.
   #[serde(default)]
   pub token: String,
+  /// An ssh private key, in plain text on the db, used for repos
+  /// cloned over ssh. Same security caveat as `token`.
+  ///
+  /// Leave empty to use the ssh config of the host running the clone.
+  #[serde(default)]
+  pub ssh_key: String,
 }
 
 fn default_git_domain() -> String {

--- a/client/core/rs/src/entities/repo.rs
+++ b/client/core/rs/src/entities/repo.rs
@@ -161,11 +161,20 @@ pub struct RepoConfig {
 
   /// Whether to use https to clone the repo (versus http). Default: true
   ///
-  /// Note. Komodo does not currently support cloning repos via ssh.
+  /// Ignored if `git_ssh` is enabled.
   #[serde(default = "default_git_https")]
   #[builder(default = "default_git_https()")]
   #[partial_default(default_git_https())]
   pub git_https: bool,
+
+  /// Clone over ssh (`git@{git_provider}:{repo}`) instead of http(s).
+  ///
+  /// The ssh key is provided by the host running the clone,
+  /// via its ssh config / agent - Komodo does not manage keys.
+  /// `git_account` is not used in this mode.
+  #[serde(default)]
+  #[builder(default)]
+  pub git_ssh: bool,
 
   /// The git account used to access private repos.
   /// Passing empty string can only clone public repos.
@@ -299,6 +308,7 @@ impl Default for RepoConfig {
       builder_id: Default::default(),
       git_provider: default_git_provider(),
       git_https: default_git_https(),
+      git_ssh: false,
       repo: Default::default(),
       branch: default_branch(),
       commit: Default::default(),

--- a/client/core/rs/src/entities/stack.rs
+++ b/client/core/rs/src/entities/stack.rs
@@ -437,11 +437,20 @@ pub struct StackConfig {
 
   /// Whether to use https to clone the repo (versus http). Default: true
   ///
-  /// Note. Komodo does not currently support cloning repos via ssh.
+  /// Ignored if `git_ssh` is enabled.
   #[serde(default = "default_git_https")]
   #[builder(default = "default_git_https()")]
   #[partial_default(default_git_https())]
   pub git_https: bool,
+
+  /// Clone over ssh (`git@{git_provider}:{repo}`) instead of http(s).
+  ///
+  /// The ssh key is provided by the host running the clone,
+  /// via its ssh config / agent - Komodo does not manage keys.
+  /// `git_account` is not used in this mode.
+  #[serde(default)]
+  #[builder(default)]
+  pub git_ssh: bool,
 
   /// The git account used to access private repos.
   /// Passing empty string can only clone public repos.
@@ -749,6 +758,7 @@ impl Default for StackConfig {
       linked_repo: Default::default(),
       git_provider: default_git_provider(),
       git_https: default_git_https(),
+      git_ssh: false,
       repo: Default::default(),
       branch: default_branch(),
       commit: Default::default(),

--- a/client/core/rs/src/entities/sync.rs
+++ b/client/core/rs/src/entities/sync.rs
@@ -209,11 +209,20 @@ pub struct ResourceSyncConfig {
 
   /// Whether to use https to clone the repo (versus http). Default: true
   ///
-  /// Note. Komodo does not currently support cloning repos via ssh.
+  /// Ignored if `git_ssh` is enabled.
   #[serde(default = "default_git_https")]
   #[builder(default = "default_git_https()")]
   #[partial_default(default_git_https())]
   pub git_https: bool,
+
+  /// Clone over ssh (`git@{git_provider}:{repo}`) instead of http(s).
+  ///
+  /// The ssh key is provided by the host running the clone,
+  /// via its ssh config / agent - Komodo does not manage keys.
+  /// `git_account` is not used in this mode.
+  #[serde(default)]
+  #[builder(default)]
+  pub git_ssh: bool,
 
   /// The Github repo used as the source of the build.
   #[serde(default)]
@@ -377,6 +386,7 @@ impl Default for ResourceSyncConfig {
       linked_repo: Default::default(),
       git_provider: default_git_provider(),
       git_https: default_git_https(),
+      git_ssh: false,
       repo: Default::default(),
       branch: default_branch(),
       commit: Default::default(),

--- a/client/core/ts/src/types.ts
+++ b/client/core/ts/src/types.ts
@@ -678,9 +678,17 @@ export interface BuildConfig {
 	/**
 	 * Whether to use https to clone the repo (versus http). Default: true
 	 * 
-	 * Note. Komodo does not currently support cloning repos via ssh.
+	 * Ignored if `git_ssh` is enabled.
 	 */
 	git_https: boolean;
+	/**
+	 * Clone over ssh (`git@{git_provider}:{repo}`) instead of http(s).
+	 * 
+	 * The ssh key is provided by the host running the clone,
+	 * via its ssh config / agent - Komodo does not manage keys.
+	 * `git_account` is not used in this mode.
+	 */
+	git_ssh: boolean;
 	/**
 	 * The git account used to access private repos.
 	 * Passing empty string can only clone public repos.
@@ -1090,6 +1098,13 @@ export interface GitProviderAccount {
 	 * If the database / host can be accessed this is insecure.
 	 */
 	token?: string;
+	/**
+	 * An ssh private key, in plain text on the db, used for repos
+	 * cloned over ssh. Same security caveat as `token`.
+	 * 
+	 * Leave empty to use the ssh config of the host running the clone.
+	 */
+	ssh_key?: string;
 }
 
 export type CreateGitProviderAccountResponse = GitProviderAccount;
@@ -2051,9 +2066,17 @@ export interface RepoConfig {
 	/**
 	 * Whether to use https to clone the repo (versus http). Default: true
 	 * 
-	 * Note. Komodo does not currently support cloning repos via ssh.
+	 * Ignored if `git_ssh` is enabled.
 	 */
 	git_https: boolean;
+	/**
+	 * Clone over ssh (`git@{git_provider}:{repo}`) instead of http(s).
+	 * 
+	 * The ssh key is provided by the host running the clone,
+	 * via its ssh config / agent - Komodo does not manage keys.
+	 * `git_account` is not used in this mode.
+	 */
+	git_ssh: boolean;
 	/**
 	 * The git account used to access private repos.
 	 * Passing empty string can only clone public repos.
@@ -2148,9 +2171,17 @@ export interface ResourceSyncConfig {
 	/**
 	 * Whether to use https to clone the repo (versus http). Default: true
 	 * 
-	 * Note. Komodo does not currently support cloning repos via ssh.
+	 * Ignored if `git_ssh` is enabled.
 	 */
 	git_https: boolean;
+	/**
+	 * Clone over ssh (`git@{git_provider}:{repo}`) instead of http(s).
+	 * 
+	 * The ssh key is provided by the host running the clone,
+	 * via its ssh config / agent - Komodo does not manage keys.
+	 * `git_account` is not used in this mode.
+	 */
+	git_ssh: boolean;
 	/** The Github repo used as the source of the build. */
 	repo?: string;
 	/** The branch of the repo. */
@@ -2556,9 +2587,17 @@ export interface StackConfig {
 	/**
 	 * Whether to use https to clone the repo (versus http). Default: true
 	 * 
-	 * Note. Komodo does not currently support cloning repos via ssh.
+	 * Ignored if `git_ssh` is enabled.
 	 */
 	git_https: boolean;
+	/**
+	 * Clone over ssh (`git@{git_provider}:{repo}`) instead of http(s).
+	 * 
+	 * The ssh key is provided by the host running the clone,
+	 * via its ssh config / agent - Komodo does not manage keys.
+	 * `git_account` is not used in this mode.
+	 */
+	git_ssh: boolean;
 	/**
 	 * The git account used to access private repos.
 	 * Passing empty string can only clone public repos.
@@ -5195,8 +5234,14 @@ export type ListGitProviderAccountsResponse = GitProviderAccount[];
 export interface ProviderAccount {
 	/** The account username. Required. */
 	username: string;
-	/** The account access token. Required. */
+	/** The account access token. Required for http(s) clones. */
 	token?: string;
+	/**
+	 * An ssh private key, used for repos cloned over ssh.
+	 * 
+	 * Leave empty to use the ssh config of the host running the clone.
+	 */
+	ssh_key?: string;
 }
 
 export interface GitProvider {
@@ -10683,6 +10728,23 @@ export enum DefaultRepoFolder {
 	NotApplicable = "NotApplicable",
 }
 
+/**
+ * A credential used to access a private git repo.
+ * 
+ * Both fields may be set - the token is used for http(s) remotes,
+ * and the ssh key for ssh remotes (see `RepoExecutionArgs::ssh`).
+ */
+export interface GitCredential {
+	/** `username:token`, or a bare token. Embedded in the https remote url. */
+	token?: string;
+	/**
+	 * A private key in PEM form. Written to a temporary file with mode
+	 * 0600 for the duration of the git command, and passed to git via
+	 * `core.sshCommand`.
+	 */
+	ssh_key?: string;
+}
+
 export interface RepoExecutionArgs {
 	/** Resource name (eg Build name, Repo name) */
 	name: string;
@@ -10690,6 +10752,11 @@ export interface RepoExecutionArgs {
 	provider: string;
 	/** Use https (vs http). */
 	https: boolean;
+	/**
+	 * Clone over ssh (`git@{provider}:{repo}`) instead of http(s).
+	 * Key handling is left to the host's ssh config / agent.
+	 */
+	ssh: boolean;
 	/** Configure the account used to access repo (if private) */
 	account?: string;
 	/**

--- a/client/periphery/rs/src/api/compose.rs
+++ b/client/periphery/rs/src/api/compose.rs
@@ -1,5 +1,6 @@
 use komodo_client::entities::{
-  FileContents, RepoExecutionResponse, SearchCombinator,
+  FileContents, GitCredential, RepoExecutionResponse,
+  SearchCombinator,
   repo::Repo,
   stack::{Stack, StackFileDependency, StackRemoteFileContents},
   update::Log,
@@ -121,7 +122,7 @@ pub struct WriteCommitComposeContents {
   /// The contents to write.
   pub contents: String,
   /// If provided, use it to login in. Otherwise check periphery local git providers.
-  pub git_token: Option<String>,
+  pub git_credential: Option<GitCredential>,
 }
 
 //
@@ -141,7 +142,7 @@ pub struct ComposePull {
   /// The linked repo, if it exists.
   pub repo: Option<Repo>,
   /// If provided, use it to login in. Otherwise check periphery local git providers.
-  pub git_token: Option<String>,
+  pub git_credential: Option<GitCredential>,
   /// If provided, use it to login in. Otherwise check periphery local registry providers.
   pub registry_token: Option<String>,
   /// Propogate any secret replacers from core interpolation.
@@ -176,7 +177,7 @@ pub struct ComposeUp {
   /// The linked repo, if it exists.
   pub repo: Option<Repo>,
   /// If provided, use it to login in. Otherwise check periphery local registries.
-  pub git_token: Option<String>,
+  pub git_credential: Option<GitCredential>,
   /// If provided, use it to login in. Otherwise check periphery local git providers.
   pub registry_token: Option<String>,
   /// Propogate any secret replacers from core interpolation.
@@ -218,7 +219,7 @@ pub struct ComposeRun {
   /// The linked repo, if it exists.
   pub repo: Option<Repo>,
   /// If provided, use it to login in. Otherwise check periphery local registries.
-  pub git_token: Option<String>,
+  pub git_credential: Option<GitCredential>,
   /// If provided, use it to login in. Otherwise check periphery local git providers.
   pub registry_token: Option<String>,
   /// Propogate any secret replacers from core interpolation.

--- a/client/periphery/rs/src/api/git.rs
+++ b/client/periphery/rs/src/api/git.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
 use komodo_client::entities::{
-  EnvironmentVar, LatestCommit, RepoExecutionArgs,
+  EnvironmentVar, GitCredential, LatestCommit, RepoExecutionArgs,
   RepoExecutionResponse, SystemCommand, update::Log,
 };
 use mogh_resolver::Resolve;
@@ -23,8 +23,8 @@ pub struct GetLatestCommit {
 #[error(anyhow::Error)]
 pub struct CloneRepo {
   pub args: RepoExecutionArgs,
-  /// Override git token with one sent from core.
-  pub git_token: Option<String>,
+  /// Override the git credential with one sent from core.
+  pub git_credential: Option<GitCredential>,
   #[serde(default)]
   pub environment: Vec<EnvironmentVar>,
   /// Relative to repo root
@@ -50,8 +50,8 @@ fn default_env_file_path() -> String {
 #[error(anyhow::Error)]
 pub struct PullRepo {
   pub args: RepoExecutionArgs,
-  /// Override git token with one sent from core.
-  pub git_token: Option<String>,
+  /// Override the git credential with one sent from core.
+  pub git_credential: Option<GitCredential>,
   #[serde(default)]
   pub environment: Vec<EnvironmentVar>,
   #[serde(default = "default_env_file_path")]
@@ -72,8 +72,8 @@ pub struct PullRepo {
 #[error(anyhow::Error)]
 pub struct PullOrCloneRepo {
   pub args: RepoExecutionArgs,
-  /// Override git token with one sent from core.
-  pub git_token: Option<String>,
+  /// Override the git credential with one sent from core.
+  pub git_credential: Option<GitCredential>,
   #[serde(default)]
   pub environment: Vec<EnvironmentVar>,
   #[serde(default = "default_env_file_path")]

--- a/client/periphery/rs/src/api/swarm.rs
+++ b/client/periphery/rs/src/api/swarm.rs
@@ -1,5 +1,5 @@
 use komodo_client::entities::{
-  SearchCombinator,
+  GitCredential, SearchCombinator,
   deployment::Deployment,
   docker::{
     SwarmLists,
@@ -97,7 +97,7 @@ pub struct DeploySwarmStack {
   /// The linked repo, if it exists.
   pub repo: Option<Repo>,
   /// If provided, use it to login in. Otherwise check periphery local registries.
-  pub git_token: Option<String>,
+  pub git_credential: Option<GitCredential>,
   /// If provided, use it to login in. Otherwise check periphery local git providers.
   pub registry_token: Option<String>,
   /// Propogate any secret replacers from core interpolation.

--- a/docsite/docs/configuration/providers.md
+++ b/docsite/docs/configuration/providers.md
@@ -41,12 +41,65 @@ This includes GitHub, GitLab,
 [Bitbucket](https://github.com/moghtech/komodo/issues/387#issuecomment-3240726344),
 Forgejo, Gitea, and many other git providers.
 
+### Cloning over SSH
+
+Builds, Repos, Stacks, and Resource Syncs can instead clone over SSH by enabling
+**`git_ssh`** on the resource (in the UI, click the `https://` button next to the
+git provider until it reads `git@`). The remote becomes:
+
+```shell
+git clone git@<domain>:<Owner>/<Repo>
+```
+
+This is useful where a personal access token is undesirable - GitHub deploy keys, for
+example, are scoped to a single repository and are not tied to a user account.
+
+There are two ways to supply the key.
+
+#### 1. The host's ssh config
+
+Leave the account's `ssh_key` empty (or attach no account at all) and git uses the ssh
+config of whichever host performs the clone - Core for Resource Syncs, the target
+server's Periphery otherwise. Place the key at `~/.ssh/id_ed25519` for the user
+Periphery runs as, or add a `Host` entry to that user's `~/.ssh/config`, and make sure
+the provider's host key is in `known_hosts`.
+
+Best when you already manage host keys with configuration management.
+
+#### 2. Komodo-managed key
+
+Set `ssh_key` on the git provider account, either in **Settings > Providers** or in a
+config file. Komodo then distributes the key to whichever server runs the clone, the
+same way it distributes tokens today, so a new server needs no ssh setup of its own:
+
+```toml
+# in core.config.toml or periphery.config.toml
+
+[[git_provider]]
+domain = "github.com"
+accounts = [
+  { username = "my-user", ssh_key = """
+-----BEGIN OPENSSH PRIVATE KEY-----
+...
+-----END OPENSSH PRIVATE KEY-----
+""" },
+]
+```
+
+The key is written to a temporary file with mode `0600` for the duration of each git
+command and removed immediately afterwards. It is passed to git via `core.sshCommand`
+with `IdentitiesOnly=yes` and `StrictHostKeyChecking=accept-new`, so the provider's
+host key is trusted on first use rather than needing to be seeded.
+
+An `ssh_key` stored on an account is held in plain text, exactly like `token` - the
+same caveats about database and host access apply. Prefer a read-only key.
+
 ### Fields
 
 | Field | Default | Description |
 |-------|---------|-------------|
 | `domain` | `github.com` | The hostname of the git provider. Do not include the protocol (`http://` or `https://`). |
-| `https` | `true` | Whether to clone over HTTPS. Set to `false` for HTTP (e.g. local development). |
+| `https` | `true` | Whether to clone over HTTPS. Set to `false` for HTTP (e.g. local development). Ignored when the resource has `git_ssh` enabled. |
 | `accounts` | `[]` | A list of `{ username, token }` pairs. Each account provides access to repos visible to that user. |
 
 ### Configuration

--- a/lib/git/src/clone.rs
+++ b/lib/git/src/clone.rs
@@ -4,11 +4,14 @@ use anyhow::Context;
 use command::{CommandOptions, run_komodo_standard_command};
 use formatting::format_serror;
 use komodo_client::entities::{
-  RepoExecutionArgs, RepoExecutionResponse, all_logs_success,
-  update::Log,
+  GitCredential, RepoExecutionArgs, RepoExecutionResponse,
+  all_logs_success, update::Log,
 };
 
-use crate::{check_installed, get_commit_hash_log};
+use crate::{
+  check_installed, get_commit_hash_log,
+  ssh::{self, SshKeyFile},
+};
 
 /// Will delete the existing repo folder,
 /// clone the repo, get the latest hash / message,
@@ -19,7 +22,7 @@ use crate::{check_installed, get_commit_hash_log};
 pub async fn clone<T>(
   clone_args: T,
   root_repo_dir: &Path,
-  access_token: Option<String>,
+  credential: Option<GitCredential>,
 ) -> anyhow::Result<RepoExecutionResponse>
 where
   T: Into<RepoExecutionArgs> + std::fmt::Debug,
@@ -27,7 +30,15 @@ where
   check_installed().await?;
 
   let args: RepoExecutionArgs = clone_args.into();
-  let repo_url = args.remote_url(access_token.as_deref())?;
+  let repo_url = args.remote_url(credential.as_ref())?;
+  let ssh_key = SshKeyFile::maybe_write(
+    args
+      .ssh
+      .then(|| credential.as_ref()?.ssh_key.as_deref())
+      .flatten(),
+  )
+  .await?;
+  let git = ssh::git(ssh_key.as_ref());
 
   let mut res = RepoExecutionResponse {
     path: args.path(root_repo_dir),
@@ -67,7 +78,7 @@ where
   }
 
   let command = format!(
-    "git clone {repo_url} {} -b {}",
+    "{git} clone {repo_url} {} -b {}",
     res.path.display(),
     args.branch
   );
@@ -79,10 +90,12 @@ where
   )
   .await;
 
-  if let Some(token) = access_token {
-    log.command = log.command.replace(&token, "<TOKEN>");
-    log.stdout = log.stdout.replace(&token, "<TOKEN>");
-    log.stderr = log.stderr.replace(&token, "<TOKEN>");
+  if let Some(token) =
+    credential.as_ref().and_then(|c| c.token.as_deref())
+  {
+    log.command = log.command.replace(token, "<TOKEN>");
+    log.stdout = log.stdout.replace(token, "<TOKEN>");
+    log.stderr = log.stderr.replace(token, "<TOKEN>");
   }
 
   res.logs.push(log);

--- a/lib/git/src/init.rs
+++ b/lib/git/src/init.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 use command::{CommandOptions, run_komodo_standard_command};
 use formatting::format_serror;
 use komodo_client::entities::{
-  RepoExecutionArgs, all_logs_success, update::Log,
+  GitCredential, RepoExecutionArgs, all_logs_success, update::Log,
 };
 
 use crate::check_installed;
@@ -11,7 +11,7 @@ use crate::check_installed;
 pub async fn init_folder_as_repo(
   folder_path: &Path,
   args: &RepoExecutionArgs,
-  access_token: Option<&str>,
+  credential: Option<&GitCredential>,
   logs: &mut Vec<Log>,
 ) {
   if let Err(e) = check_installed().await {
@@ -31,7 +31,7 @@ pub async fn init_folder_as_repo(
     return;
   }
 
-  let repo_url = match args.remote_url(access_token) {
+  let repo_url = match args.remote_url(credential) {
     Ok(url) => url,
     Err(e) => {
       logs
@@ -48,7 +48,7 @@ pub async fn init_folder_as_repo(
   )
   .await;
   // Sanitize the output
-  if let Some(token) = &access_token {
+  if let Some(token) = credential.and_then(|c| c.token.as_deref()) {
     set_remote.command = set_remote.command.replace(token, "<TOKEN>");
     set_remote.stdout = set_remote.stdout.replace(token, "<TOKEN>");
     set_remote.stderr = set_remote.stderr.replace(token, "<TOKEN>");

--- a/lib/git/src/lib.rs
+++ b/lib/git/src/lib.rs
@@ -13,6 +13,7 @@ mod init;
 mod installed;
 mod pull;
 mod pull_or_clone;
+mod ssh;
 
 pub use crate::{
   clone::clone,
@@ -21,6 +22,7 @@ pub use crate::{
   installed::check_installed,
   pull::pull,
   pull_or_clone::pull_or_clone,
+  ssh::SshKeyFile,
 };
 
 pub async fn get_commit_hash_info(

--- a/lib/git/src/pull.rs
+++ b/lib/git/src/pull.rs
@@ -6,12 +6,15 @@ use std::{
 use command::{CommandOptions, run_komodo_standard_command};
 use formatting::format_serror;
 use komodo_client::entities::{
-  RepoExecutionArgs, RepoExecutionResponse, all_logs_success,
-  komodo_timestamp, update::Log,
+  GitCredential, RepoExecutionArgs, RepoExecutionResponse,
+  all_logs_success, komodo_timestamp, update::Log,
 };
 use mogh_cache::TimeoutCache;
 
-use crate::{check_installed, get_commit_hash_log};
+use crate::{
+  check_installed, get_commit_hash_log,
+  ssh::{self, SshKeyFile},
+};
 
 /// Wait this long after a pull to allow another pull through
 const PULL_TIMEOUT: i64 = 5_000;
@@ -30,7 +33,7 @@ fn pull_cache()
 pub async fn pull<T>(
   clone_args: T,
   root_repo_dir: &Path,
-  access_token: Option<String>,
+  credential: Option<GitCredential>,
 ) -> anyhow::Result<RepoExecutionResponse>
 where
   T: Into<RepoExecutionArgs> + std::fmt::Debug,
@@ -38,7 +41,15 @@ where
   check_installed().await?;
 
   let args: RepoExecutionArgs = clone_args.into();
-  let repo_url = args.remote_url(access_token.as_deref())?;
+  let repo_url = args.remote_url(credential.as_ref())?;
+  let ssh_key = SshKeyFile::maybe_write(
+    args
+      .ssh
+      .then(|| credential.as_ref()?.ssh_key.as_deref())
+      .flatten(),
+  )
+  .await?;
+  let git = ssh::git(ssh_key.as_ref());
 
   let mut res = RepoExecutionResponse {
     path: args.path(root_repo_dir),
@@ -67,7 +78,7 @@ where
       crate::init::init_folder_as_repo(
         &res.path,
         &args,
-        access_token.as_deref(),
+        credential.as_ref(),
         &mut res.logs,
       )
       .await;
@@ -84,13 +95,13 @@ where
     )
     .await;
     // Sanitize the output
-    if let Some(token) = access_token {
+    if let Some(token) =
+      credential.as_ref().and_then(|c| c.token.as_deref())
+    {
       set_remote.command =
-        set_remote.command.replace(&token, "<TOKEN>");
-      set_remote.stdout =
-        set_remote.stdout.replace(&token, "<TOKEN>");
-      set_remote.stderr =
-        set_remote.stderr.replace(&token, "<TOKEN>");
+        set_remote.command.replace(token, "<TOKEN>");
+      set_remote.stdout = set_remote.stdout.replace(token, "<TOKEN>");
+      set_remote.stderr = set_remote.stderr.replace(token, "<TOKEN>");
     }
     res.logs.push(set_remote);
     if !all_logs_success(&res.logs) {
@@ -100,7 +111,7 @@ where
     // First fetch remote branches before checkout
     let fetch = run_komodo_standard_command(
       "Git Fetch",
-      "git fetch --all --prune",
+      format!("{git} fetch --all --prune"),
       CommandOptions::default().path(res.path.as_ref()),
     )
     .await;
@@ -122,7 +133,7 @@ where
 
     let pull_log = run_komodo_standard_command(
       "Git pull",
-      format!("git pull --rebase --force origin {}", args.branch),
+      format!("{git} pull --rebase --force origin {}", args.branch),
       CommandOptions::default().path(res.path.as_ref()),
     )
     .await;

--- a/lib/git/src/pull_or_clone.rs
+++ b/lib/git/src/pull_or_clone.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 
 use komodo_client::entities::{
-  RepoExecutionArgs, RepoExecutionResponse,
+  GitCredential, RepoExecutionArgs, RepoExecutionResponse,
 };
 
 /// This is a mix of clone / pull.
@@ -13,7 +13,7 @@ use komodo_client::entities::{
 pub async fn pull_or_clone<T>(
   clone_args: T,
   root_repo_dir: &Path,
-  access_token: Option<String>,
+  credential: Option<GitCredential>,
 ) -> anyhow::Result<(RepoExecutionResponse, bool)>
 where
   T: Into<RepoExecutionArgs> + std::fmt::Debug,
@@ -22,11 +22,11 @@ where
   let folder_path = args.path(root_repo_dir);
 
   if folder_path.exists() {
-    crate::pull(args, root_repo_dir, access_token)
+    crate::pull(args, root_repo_dir, credential)
       .await
       .map(|r| (r, false))
   } else {
-    crate::clone(args, root_repo_dir, access_token)
+    crate::clone(args, root_repo_dir, credential)
       .await
       .map(|r| (r, true))
   }

--- a/lib/git/src/ssh.rs
+++ b/lib/git/src/ssh.rs
@@ -1,0 +1,134 @@
+use std::{
+  path::PathBuf,
+  sync::atomic::{AtomicU64, Ordering},
+};
+
+use anyhow::Context;
+use komodo_client::entities::komodo_timestamp;
+
+/// A Komodo-managed ssh private key, written to a temporary file for
+/// the duration of a git command and removed afterwards.
+///
+/// When no key is configured on the git account, none of this applies -
+/// git is invoked plainly and picks up the ssh config of the host it
+/// runs on.
+pub struct SshKeyFile {
+  path: PathBuf,
+}
+
+impl SshKeyFile {
+  /// Writes the key to a private temp file. Returns `Ok(None)` if there
+  /// is no key to write, in which case the host's ssh config is used.
+  pub async fn maybe_write(
+    key: Option<&str>,
+  ) -> anyhow::Result<Option<SshKeyFile>> {
+    let Some(key) = key.map(str::trim).filter(|key| !key.is_empty())
+    else {
+      return Ok(None);
+    };
+
+    static COUNT: AtomicU64 = AtomicU64::new(0);
+    let path = std::env::temp_dir().join(format!(
+      "komodo-git-key-{}-{}-{}",
+      std::process::id(),
+      komodo_timestamp(),
+      COUNT.fetch_add(1, Ordering::Relaxed),
+    ));
+
+    // Create with 0600 up front - never let the key exist world readable,
+    // even briefly.
+    let mut options = tokio::fs::OpenOptions::new();
+    options.write(true).create_new(true);
+    #[cfg(unix)]
+    options.mode(0o600);
+    let mut file = options
+      .open(&path)
+      .await
+      .context("Failed to create temporary file for ssh key")?;
+
+    let res = async {
+      use tokio::io::AsyncWriteExt;
+      file.write_all(key.as_bytes()).await?;
+      // ssh rejects a key file without a trailing newline.
+      if !key.ends_with('\n') {
+        file.write_all(b"\n").await?;
+      }
+      file.flush().await
+    }
+    .await
+    .context("Failed to write temporary ssh key file");
+
+    if res.is_err() {
+      let _ = tokio::fs::remove_file(&path).await;
+    }
+    res?;
+
+    Ok(Some(SshKeyFile { path }))
+  }
+}
+
+impl Drop for SshKeyFile {
+  fn drop(&mut self) {
+    let _ = std::fs::remove_file(&self.path);
+  }
+}
+
+/// The git binary to invoke - plain `git`, or `git` configured to use a
+/// Komodo-managed key. The key path (never the key itself) appears in the
+/// command, so it is safe to log.
+pub fn git(key: Option<&SshKeyFile>) -> String {
+  match key {
+    Some(SshKeyFile { path }) => format!(
+      "git -c core.sshCommand=\"ssh -i {} -o IdentitiesOnly=yes -o StrictHostKeyChecking=accept-new\"",
+      path.display()
+    ),
+    None => String::from("git"),
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn no_key_means_plain_git() {
+    assert_eq!(git(None), "git");
+  }
+
+  #[tokio::test]
+  async fn key_file_is_private_and_cleaned_up() {
+    assert!(SshKeyFile::maybe_write(None).await.unwrap().is_none());
+    assert!(
+      SshKeyFile::maybe_write(Some("  ")).await.unwrap().is_none()
+    );
+
+    let key = SshKeyFile::maybe_write(Some("PRIVATE KEY"))
+      .await
+      .unwrap()
+      .expect("key should have been written");
+    let path = key.path.clone();
+
+    let contents = tokio::fs::read_to_string(&path).await.unwrap();
+    // Trailing newline is added, ssh rejects the key without it.
+    assert_eq!(contents, "PRIVATE KEY\n");
+
+    #[cfg(unix)]
+    {
+      use std::os::unix::fs::PermissionsExt;
+      let mode = tokio::fs::metadata(&path)
+        .await
+        .unwrap()
+        .permissions()
+        .mode();
+      assert_eq!(mode & 0o777, 0o600);
+    }
+
+    // The key path, never the key itself, ends up in the command.
+    let command = git(Some(&key));
+    assert!(command.contains(&path.display().to_string()));
+    assert!(!command.contains("PRIVATE KEY"));
+
+    drop(key);
+    assert!(!path.exists(), "key file should be removed on drop");
+  }
+}

--- a/ui/public/client/types.d.ts
+++ b/ui/public/client/types.d.ts
@@ -672,9 +672,17 @@ export interface BuildConfig {
     /**
      * Whether to use https to clone the repo (versus http). Default: true
      *
-     * Note. Komodo does not currently support cloning repos via ssh.
+     * Ignored if `git_ssh` is enabled.
      */
     git_https: boolean;
+    /**
+     * Clone over ssh (`git@{git_provider}:{repo}`) instead of http(s).
+     * 
+     * The ssh key is provided by the host running the clone,
+     * via its ssh config / agent - Komodo does not manage keys.
+     * `git_account` is not used in this mode.
+     */
+    git_ssh: boolean;
     /**
      * The git account used to access private repos.
      * Passing empty string can only clone public repos.
@@ -1244,6 +1252,13 @@ export interface GitProviderAccount {
      * If the database / host can be accessed this is insecure.
      */
     token?: string;
+    /**
+     * An ssh private key, in plain text on the db, used for repos
+     * cloned over ssh. Same security caveat as `token`.
+     * 
+     * Leave empty to use the ssh config of the host running the clone.
+     */
+    ssh_key?: string;
 }
 export type CreateGitProviderAccountResponse = GitProviderAccount;
 /** Configuration to access private image repositories on various registries. */
@@ -2218,9 +2233,17 @@ export interface RepoConfig {
     /**
      * Whether to use https to clone the repo (versus http). Default: true
      *
-     * Note. Komodo does not currently support cloning repos via ssh.
+     * Ignored if `git_ssh` is enabled.
      */
     git_https: boolean;
+    /**
+     * Clone over ssh (`git@{git_provider}:{repo}`) instead of http(s).
+     * 
+     * The ssh key is provided by the host running the clone,
+     * via its ssh config / agent - Komodo does not manage keys.
+     * `git_account` is not used in this mode.
+     */
+    git_ssh: boolean;
     /**
      * The git account used to access private repos.
      * Passing empty string can only clone public repos.
@@ -2309,9 +2332,17 @@ export interface ResourceSyncConfig {
     /**
      * Whether to use https to clone the repo (versus http). Default: true
      *
-     * Note. Komodo does not currently support cloning repos via ssh.
+     * Ignored if `git_ssh` is enabled.
      */
     git_https: boolean;
+    /**
+     * Clone over ssh (`git@{git_provider}:{repo}`) instead of http(s).
+     * 
+     * The ssh key is provided by the host running the clone,
+     * via its ssh config / agent - Komodo does not manage keys.
+     * `git_account` is not used in this mode.
+     */
+    git_ssh: boolean;
     /** The Github repo used as the source of the build. */
     repo?: string;
     /** The branch of the repo. */
@@ -2704,9 +2735,17 @@ export interface StackConfig {
     /**
      * Whether to use https to clone the repo (versus http). Default: true
      *
-     * Note. Komodo does not currently support cloning repos via ssh.
+     * Ignored if `git_ssh` is enabled.
      */
     git_https: boolean;
+    /**
+     * Clone over ssh (`git@{git_provider}:{repo}`) instead of http(s).
+     * 
+     * The ssh key is provided by the host running the clone,
+     * via its ssh config / agent - Komodo does not manage keys.
+     * `git_account` is not used in this mode.
+     */
+    git_ssh: boolean;
     /**
      * The git account used to access private repos.
      * Passing empty string can only clone public repos.
@@ -5107,8 +5146,14 @@ export type ListGitProviderAccountsResponse = GitProviderAccount[];
 export interface ProviderAccount {
     /** The account username. Required. */
     username: string;
-    /** The account access token. Required. */
+    /** The account access token. Required for http(s) clones. */
     token?: string;
+    /**
+     * An ssh private key, used for repos cloned over ssh.
+     * 
+     * Leave empty to use the ssh config of the host running the clone.
+     */
+    ssh_key?: string;
 }
 export interface GitProvider {
     /** The git provider domain. Default: `github.com`. */
@@ -10154,6 +10199,23 @@ export declare enum DefaultRepoFolder {
      */
     NotApplicable = "NotApplicable"
 }
+/**
+ * A credential used to access a private git repo.
+ * 
+ * Both fields may be set - the token is used for http(s) remotes,
+ * and the ssh key for ssh remotes (see `RepoExecutionArgs::ssh`).
+ */
+export interface GitCredential {
+    /** `username:token`, or a bare token. Embedded in the https remote url. */
+    token?: string;
+    /**
+     * A private key in PEM form. Written to a temporary file with mode
+     * 0600 for the duration of the git command, and passed to git via
+     * `core.sshCommand`.
+     */
+    ssh_key?: string;
+}
+
 export interface RepoExecutionArgs {
     /** Resource name (eg Build name, Repo name) */
     name: string;
@@ -10161,6 +10223,11 @@ export interface RepoExecutionArgs {
     provider: string;
     /** Use https (vs http). */
     https: boolean;
+    /**
+     * Clone over ssh (`git@{provider}:{repo}`) instead of http(s).
+     * Key handling is left to the host's ssh config / agent.
+     */
+    ssh: boolean;
     /** Configure the account used to access repo (if private) */
     account?: string;
     /**

--- a/ui/src/components/config/linked-repo.tsx
+++ b/ui/src/components/config/linked-repo.tsx
@@ -13,6 +13,7 @@ export interface LinkedRepoProps {
     git_provider: string;
     git_account: string;
     git_https: boolean;
+    git_ssh: boolean;
     repo: string;
     branch: string;
     commit: string;
@@ -55,6 +56,7 @@ export default function LinkedRepo({
             git_provider: "github.com",
             git_account: "",
             git_https: true,
+            git_ssh: false,
             repo: linkedRepo ? "" : "namespace/repo",
             branch: "main",
             commit: "",

--- a/ui/src/components/config/provider-selector.tsx
+++ b/ui/src/components/config/provider-selector.tsx
@@ -92,12 +92,15 @@ export default function ProviderSelector({
 export function ProviderSelectorConfig({
   description,
   https,
+  ssh,
   onHttpsSwitch,
   accountType,
   ...props
 }: {
   description?: string;
   https?: boolean;
+  ssh?: boolean;
+  /** Cycles the clone scheme: https:// -> http:// -> git@ */
   onHttpsSwitch?: () => void;
 } & ProviderSelectorProps) {
   const select = accountType === "git" ? "git provider" : "docker registry";
@@ -118,7 +121,7 @@ export function ProviderSelectorConfig({
             px="sm"
             py="xs"
           >
-            {`http${https ? "s" : ""}://`}
+            {ssh ? "git@" : `http${https ? "s" : ""}://`}
           </Button>
           {selector}
         </Group>

--- a/ui/src/pages/settings/providers/index.tsx
+++ b/ui/src/pages/settings/providers/index.tsx
@@ -218,6 +218,50 @@ function Providers({ type }: { type: "GitProvider" | "ImageRegistry" }) {
                 );
               },
             },
+            ...(type === "GitProvider"
+              ? [
+                  {
+                    accessorKey: "ssh_key",
+                    size: 200,
+                    header: ({ column }: any) => (
+                      <SortableHeader column={column} title="SSH Key" />
+                    ),
+                    cell: ({ row }: any) => {
+                      return (
+                        <Group gap="sm" wrap="nowrap">
+                          <Button
+                            className="overflow-ellipsis"
+                            onClick={(e: any) => {
+                              e.stopPropagation();
+                              setUpdateMenuData({
+                                title: "Set SSH Key",
+                                value: row.original.ssh_key ?? "",
+                                placeholder:
+                                  "Paste private key, or leave empty to use the host ssh config",
+                                onUpdate: (ssh_key: string) => {
+                                  if (row.original.ssh_key === ssh_key) {
+                                    return;
+                                  }
+                                  updateAccount({
+                                    id: row.original._id?.$oid!,
+                                    account: { ssh_key },
+                                  });
+                                },
+                              });
+                            }}
+                            w={{ base: 200, lg: 300 }}
+                            justify="start"
+                          >
+                            {"*".repeat(row.original.ssh_key?.length || 0) || (
+                              <Text c="dimmed">Set ssh key</Text>
+                            )}
+                          </Button>
+                        </Group>
+                      );
+                    },
+                  },
+                ]
+              : []),
             {
               header: "Delete",
               maxSize: 200,

--- a/ui/src/pages/settings/providers/new.tsx
+++ b/ui/src/pages/settings/providers/new.tsx
@@ -24,6 +24,7 @@ export default function NewProviderAccount({
   const [https, setHttps] = useState(true);
   const [username, setUsername] = useState("");
   const [token, setToken] = useState("");
+  const [sshKey, setSshKey] = useState("");
   const invalidate = useInvalidate();
   const { mutate: create, isPending } = useWrite(`Create${type}Account`, {
     onSuccess: () => {
@@ -32,7 +33,16 @@ export default function NewProviderAccount({
       close();
     },
   });
-  const submit = () => create({ account: { domain, https, username, token } });
+  const submit = () =>
+    create({
+      account: {
+        domain,
+        https,
+        username,
+        token,
+        ...(type === "GitProvider" ? { ssh_key: sshKey } : {}),
+      },
+    });
 
   const form: Array<
     | undefined
@@ -60,6 +70,14 @@ export default function NewProviderAccount({
       (e: ChangeEvent<HTMLInputElement>) => setToken(e.target.value),
       false,
     ],
+    type === "GitProvider"
+      ? [
+          "SSH Key",
+          sshKey,
+          (e: ChangeEvent<HTMLInputElement>) => setSshKey(e.target.value),
+          false,
+        ]
+      : undefined,
   ];
   const accountType =
     type === "ImageRegistry" ? "Registry Account" : "Git Account";

--- a/ui/src/resources/build/config.tsx
+++ b/ui/src/resources/build/config.tsx
@@ -496,6 +496,7 @@ export default function BuildConfig({
               ? {
                   git_provider: (provider, set) => {
                     const https = update.git_https ?? config.git_https;
+                    const ssh = update.git_ssh ?? config.git_ssh;
                     return (
                       <ProviderSelectorConfig
                         accountType="git"
@@ -503,7 +504,16 @@ export default function BuildConfig({
                         disabled={disabled}
                         onSelect={(git_provider) => set({ git_provider })}
                         https={https}
-                        onHttpsSwitch={() => set({ git_https: !https })}
+                        ssh={ssh}
+                        onHttpsSwitch={() =>
+                          set(
+                            ssh
+                              ? { git_ssh: false, git_https: true }
+                              : https
+                                ? { git_https: false }
+                                : { git_ssh: true }
+                          )
+                        }
                       />
                     );
                   },

--- a/ui/src/resources/repo/config.tsx
+++ b/ui/src/resources/repo/config.tsx
@@ -136,6 +136,7 @@ export default function RepoConfig({
             fields: {
               git_provider: (provider, set) => {
                 const https = update.git_https ?? config.git_https;
+                const ssh = update.git_ssh ?? config.git_ssh;
                 return (
                   <ProviderSelectorConfig
                     accountType="git"
@@ -143,7 +144,16 @@ export default function RepoConfig({
                     disabled={disabled}
                     onSelect={(git_provider) => set({ git_provider })}
                     https={https}
-                    onHttpsSwitch={() => set({ git_https: !https })}
+                    ssh={ssh}
+                    onHttpsSwitch={() =>
+                      set(
+                        ssh
+                          ? { git_ssh: false, git_https: true }
+                          : https
+                            ? { git_https: false }
+                            : { git_ssh: true }
+                      )
+                    }
                   />
                 );
               },

--- a/ui/src/resources/stack/config/index.tsx
+++ b/ui/src/resources/stack/config/index.tsx
@@ -789,6 +789,7 @@ export default function StackConfig({
               ? {
                   git_provider: (provider, set) => {
                     const https = update.git_https ?? config.git_https;
+                    const ssh = update.git_ssh ?? config.git_ssh;
                     return (
                       <ProviderSelectorConfig
                         accountType="git"
@@ -796,7 +797,16 @@ export default function StackConfig({
                         disabled={disabled}
                         onSelect={(git_provider) => set({ git_provider })}
                         https={https}
-                        onHttpsSwitch={() => set({ git_https: !https })}
+                        ssh={ssh}
+                        onHttpsSwitch={() =>
+                          set(
+                            ssh
+                              ? { git_ssh: false, git_https: true }
+                              : https
+                                ? { git_https: false }
+                                : { git_ssh: true }
+                          )
+                        }
                       />
                     );
                   },

--- a/ui/src/resources/sync/config.tsx
+++ b/ui/src/resources/sync/config.tsx
@@ -265,6 +265,7 @@ export default function ResourceSyncConfig({
           ? {
               git_provider: (provider: string | undefined, set) => {
                 const https = update.git_https ?? config.git_https;
+                const ssh = update.git_ssh ?? config.git_ssh;
                 return (
                   <ProviderSelectorConfig
                     accountType="git"
@@ -272,7 +273,16 @@ export default function ResourceSyncConfig({
                     disabled={disabled}
                     onSelect={(git_provider) => set({ git_provider })}
                     https={https}
-                    onHttpsSwitch={() => set({ git_https: !https })}
+                    ssh={ssh}
+                    onHttpsSwitch={() =>
+                      set(
+                        ssh
+                          ? { git_ssh: false, git_https: true }
+                          : https
+                            ? { git_https: false }
+                            : { git_ssh: true }
+                      )
+                    }
                   />
                 );
               },


### PR DESCRIPTION
Addresses #758.

Komodo only accepts `{ username, token }` today, which is always a user-scoped credential. Some credentials can't be expressed that way — a GitHub deploy key is scoped to one repo and isn't tied to an account. #1537 is the related complaint about the token ending up in `.git/config`.

This adds a `git_ssh` option to Build, Repo, Stack and ResourceSync. When set, `remote_url()` returns `git@{git_provider}:{repo}` and no token is embedded.

The key can come from either side:

- **Account `ssh_key` empty** — git uses the ssh config of whichever host runs the clone (Core for syncs, the target server's Periphery otherwise).
- **Account `ssh_key` set** — Core sends it with the request, as it already does with tokens, so a new server needs no ssh setup. Periphery writes it to a `0600` temp file, passes it via `core.sshCommand` with `IdentitiesOnly=yes` and `StrictHostKeyChecking=accept-new`, and removes it on drop. Only the path reaches the command string.

To carry both, the credential on the wire is now `GitCredential { token, ssh_key }` instead of `Option<String>`. That rename is most of the diff; the behaviour change is small.

In the UI the existing `https://`/`http://` button next to the git provider becomes a three-way cycle ending in `git@`, and git accounts get an `SSH Key` field.

Tests cover `remote_url` in both forms, and the key file's mode, cleanup on drop, and that the key body never reaches the command. `cargo check --workspace --all-targets` and `cargo fmt --all` are clean. I haven't run the UI build, so the four `config.tsx` changes and the regenerated types are worth a look.
