### PR TITLE
feat: :sparkles: S.M.A.R.T status report

### DIFF
--- a/bin/core/src/alert/discord.rs
+++ b/bin/core/src/alert/discord.rs
@@ -117,12 +117,23 @@ pub async fn send_alert(
       path,
       used_gb,
       total_gb,
+      healthy,
+      temperature,
     } => {
       let region = fmt_region(region);
       let link = resource_link(ResourceTargetVariant::Server, id);
       let percentage = 100.0 * used_gb / total_gb;
+      let mut extra = String::new();
+      if *healthy == Some(false) {
+        extra.push_str("\nSMART Health: **FAILED** ❌");
+      }
+      if let Some(temp) = temperature
+        && *temp > 0
+      {
+        extra.push_str(&format!("\nTemperature: **{temp}°C**"));
+      }
       format!(
-        "{level} | **{name}**{region} disk usage at **{percentage:.1}%** 💿\nmount point: `{path:?}`\nusing **{used_gb:.1} GiB** / **{total_gb:.1} GiB**\n{link}"
+        "{level} | **{name}**{region} disk alert at **{percentage:.1}%** 💿\nmount point: `{path:?}`\nusing **{used_gb:.1} GiB** / **{total_gb:.1} GiB**{extra}\n{link}"
       )
     }
     AlertData::ContainerStateChange {

--- a/bin/core/src/alert/mod.rs
+++ b/bin/core/src/alert/mod.rs
@@ -348,12 +348,23 @@ fn standard_alert_content(alert: &Alert) -> String {
       path,
       used_gb,
       total_gb,
+      healthy,
+      temperature,
     } => {
       let region = fmt_region(region);
       let link = resource_link(ResourceTargetVariant::Server, id);
       let percentage = 100.0 * used_gb / total_gb;
+      let mut extra = String::new();
+      if *healthy == Some(false) {
+        extra.push_str("\nSMART Health: FAILED ❌");
+      }
+      if let Some(temp) = temperature
+        && *temp > 0
+      {
+        extra.push_str(&format!("\nTemperature: {temp}°C"));
+      }
       format!(
-        "{level} | {name}{region} disk usage at {percentage:.1}%💿\nmount point: {path:?}\nusing {used_gb:.1} GiB / {total_gb:.1} GiB\n{link}",
+        "{level} | {name}{region} disk alert at {percentage:.1}% 💿\nmount point: {path:?}\nusing {used_gb:.1} GiB / {total_gb:.1} GiB{extra}\n{link}",
       )
     }
     AlertData::ContainerStateChange {

--- a/bin/core/src/alert/slack.rs
+++ b/bin/core/src/alert/slack.rs
@@ -228,49 +228,37 @@ pub async fn send_alert(
       path,
       used_gb,
       total_gb,
+      healthy,
+      temperature,
     } => {
       let region = fmt_region(region);
       let percentage = 100.0 * used_gb / total_gb;
-      match alert.level {
-        SeverityLevel::Ok => {
-          let text = format!(
-            "{level} | *{name}*{region} disk usage at *{percentage:.1}%* | mount point: *{path:?}* 💿"
-          );
-          let blocks = vec![
-            Block::header(level),
-            Block::section(format!(
-              "*{name}*{region} disk usage at *{percentage:.1}%* 💿"
-            )),
-            Block::section(format!(
-              "mount point: {path:?} | using *{used_gb:.1} GiB* / *{total_gb:.1} GiB*"
-            )),
-            Block::section(resource_link(
-              ResourceTargetVariant::Server,
-              id,
-            )),
-          ];
-          (text, blocks.into())
-        }
-        _ => {
-          let text = format!(
-            "{level} | *{name}*{region} disk usage at *{percentage:.1}%* | mount point: *{path:?}* 💿"
-          );
-          let blocks = vec![
-            Block::header(level),
-            Block::section(format!(
-              "*{name}*{region} disk usage at *{percentage:.1}%* 💿"
-            )),
-            Block::section(format!(
-              "mount point: {path:?} | using *{used_gb:.1} GiB* / *{total_gb:.1} GiB*"
-            )),
-            Block::section(resource_link(
-              ResourceTargetVariant::Server,
-              id,
-            )),
-          ];
-          (text, blocks.into())
-        }
+      let mut extra = String::new();
+      if *healthy == Some(false) {
+        extra.push_str("\nSMART Health: *FAILED* ❌");
       }
+      if let Some(temp) = temperature
+        && *temp > 0
+      {
+        extra.push_str(&format!("\nTemperature: *{temp}°C*"));
+      }
+      let text = format!(
+        "{level} | *{name}*{region} disk alert at *{percentage:.1}%* | mount point: *{path:?}* 💿"
+      );
+      let blocks = vec![
+        Block::header(level),
+        Block::section(format!(
+          "*{name}*{region} disk alert at *{percentage:.1}%* 💿"
+        )),
+        Block::section(format!(
+          "mount point: {path:?} | using *{used_gb:.1} GiB* / *{total_gb:.1} GiB*{extra}"
+        )),
+        Block::section(resource_link(
+          ResourceTargetVariant::Server,
+          id,
+        )),
+      ];
+      (text, blocks.into())
     }
     AlertData::ContainerStateChange {
       name,

--- a/bin/core/src/monitor/alert/server.rs
+++ b/bin/core/src/monitor/alert/server.rs
@@ -531,6 +531,8 @@ pub async fn alert_servers(
                   .map(|d| d.total_gb)
                   .unwrap_or_default(),
                 used_gb: disk.map(|d| d.used_gb).unwrap_or_default(),
+                healthy: disk.and_then(|d| d.healthy),
+                temperature: disk.map(|d| d.temperature),
               },
             };
             alerts_to_open
@@ -557,6 +559,8 @@ pub async fn alert_servers(
               path: path.to_owned(),
               total_gb: disk.map(|d| d.total_gb).unwrap_or_default(),
               used_gb: disk.map(|d| d.used_gb).unwrap_or_default(),
+              healthy: disk.and_then(|d| d.healthy),
+              temperature: disk.map(|d| d.temperature),
             };
             alerts_to_update
               .push((alert, server.config.send_disk_alerts));
@@ -584,6 +588,8 @@ pub async fn alert_servers(
             path: path.to_owned(),
             total_gb: disk.map(|d| d.total_gb).unwrap_or_default(),
             used_gb: disk.map(|d| d.used_gb).unwrap_or_default(),
+            healthy: disk.and_then(|d| d.healthy),
+            temperature: disk.map(|d| d.temperature),
           };
           alerts_to_close
             .push((alert, server.config.send_disk_alerts))

--- a/bin/core/src/monitor/helpers.rs
+++ b/bin/core/src/monitor/helpers.rs
@@ -157,6 +157,8 @@ fn get_server_health(
     mount,
     used_gb,
     total_gb,
+    healthy,
+    temperature,
     ..
   } in disks
   {
@@ -171,6 +173,22 @@ fn get_server_health(
     {
       state.should_close_alert = true;
     };
+
+    if healthy == &Some(false) {
+      state.level = SeverityLevel::Critical;
+      state.should_close_alert = false;
+    }
+
+    if *temperature >= 60 {
+      state.level = SeverityLevel::Critical;
+      state.should_close_alert = false;
+    } else if *temperature >= 50 {
+      if state.level < SeverityLevel::Warning {
+        state.level = SeverityLevel::Warning;
+      }
+      state.should_close_alert = false;
+    }
+
     health.disks.insert(mount.clone(), state);
   }
 

--- a/bin/periphery/debian-deps.sh
+++ b/bin/periphery/debian-deps.sh
@@ -3,7 +3,7 @@
 ## Periphery deps installer
 
 apt-get update
-apt-get install -y git curl wget ca-certificates
+apt-get install -y git curl wget ca-certificates smartmontools util-linux
 
 install -m 0755 -d /etc/apt/keyrings
 curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc

--- a/bin/periphery/src/stats/disk.rs
+++ b/bin/periphery/src/stats/disk.rs
@@ -1,0 +1,137 @@
+use std::process::Command;
+
+use serde::Deserialize;
+
+#[derive(Deserialize, Debug)]
+pub struct SmartStatus {
+  pub passed: Option<bool>,
+}
+
+#[derive(Deserialize, Debug)]
+struct SmartReport {
+  pub smart_status: Option<SmartStatus>,
+}
+
+/// Parse smartctl JSON output string to extract health status.
+pub fn parse_smart_status(json_str: &str) -> Option<bool> {
+  let report: SmartReport = serde_json::from_str(json_str).ok()?;
+  report.smart_status?.passed
+}
+
+/// given a device path it will try to get the SMART data about it returning true/false to indicate healthy or not otherwise it returns None
+pub fn get_smart_data(device_path: &str) -> Option<bool> {
+  let output = Command::new("smartctl")
+    .args(["-H", device_path, "-j"])
+    .output()
+    .ok()?;
+  if output.status.success() || !output.stdout.is_empty() {
+    let json_str = String::from_utf8_lossy(&output.stdout);
+    return parse_smart_status(&json_str);
+  }
+  None
+}
+
+#[derive(Deserialize, Debug)]
+pub struct LsblkOutput {
+  pub blockdevices: Vec<LsblkDevice>,
+}
+
+#[derive(Deserialize, Debug)]
+pub struct LsblkDevice {
+  pub name: String,
+  /// 'type' is a reserved keyword in Rust, so rename it
+  #[serde(rename = "type")]
+  pub device_type: String,
+  /// Leaf nodes will not have children, so default to empty Vec
+  #[serde(default)]
+  pub children: Vec<LsblkDevice>,
+}
+
+impl LsblkDevice {
+  /// Recursively traverse the tree to find the physical disk name ('type' == "disk")
+  pub fn find_physical_disk(&self) -> Option<String> {
+    if self.device_type == "disk" {
+      return Some(self.name.clone());
+    }
+    for child in &self.children {
+      if let Some(disk_name) = child.find_physical_disk() {
+        return Some(disk_name);
+      }
+    }
+    None
+  }
+}
+
+pub fn volume_to_device_mapper(mapper: &str) -> Option<String> {
+  let output = Command::new("lsblk")
+    .args(["-s", "-J", mapper])
+    .output()
+    .ok()?;
+  if !output.status.success() || output.stdout.is_empty() {
+    return None;
+  }
+  let output: Option<LsblkOutput> =
+    serde_json::from_str(&String::from_utf8_lossy(&output.stdout))
+      .ok()?;
+  let output = output.unwrap();
+  let disk_name = output
+    .blockdevices
+    .iter()
+    .find_map(|dev| dev.find_physical_disk())?;
+
+  Some(format!("/dev/{disk_name}"))
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn test_parse_healthy_drive() {
+    let json = r#"{
+      "smart_status": {
+        "passed": true
+      }
+    }"#;
+    assert_eq!(parse_smart_status(json), Some(true));
+  }
+
+  #[test]
+  fn test_parse_failing_drive() {
+    let json = r#"{
+      "smart_status": {
+        "passed": false
+      }
+    }"#;
+    assert_eq!(parse_smart_status(json), Some(false));
+  }
+
+  #[test]
+  fn test_parse_nvme_drive() {
+    let json = r#"{
+      "smart_status": {
+        "passed": true,
+        "nvme": {
+          "value": 0
+        }
+      }
+    }"#;
+    assert_eq!(parse_smart_status(json), Some(true));
+  }
+
+  #[test]
+  fn test_parse_unsupported_or_missing_smart() {
+    let json = r#"{
+      "device": {
+        "name": "/dev/loop0",
+        "type": "loop"
+      }
+    }"#;
+    assert_eq!(parse_smart_status(json), None);
+  }
+
+  #[test]
+  fn test_parse_invalid_json() {
+    assert_eq!(parse_smart_status("invalid json string"), None);
+  }
+}

--- a/bin/periphery/src/stats/disk.rs
+++ b/bin/periphery/src/stats/disk.rs
@@ -2,31 +2,46 @@ use std::process::Command;
 
 use serde::Deserialize;
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, PartialEq, Eq, Default)]
 pub struct SmartStatus {
-  pub passed: Option<bool>,
+  pub passed: bool,
 }
 
-#[derive(Deserialize, Debug)]
-struct SmartReport {
-  pub smart_status: Option<SmartStatus>,
+#[derive(Deserialize, Debug, PartialEq, Eq, Default)]
+pub struct PowerOnTime {
+  #[serde(default)]
+  pub hours: u64,
 }
 
-/// Parse smartctl JSON output string to extract health status.
-pub fn parse_smart_status(json_str: &str) -> Option<bool> {
-  let report: SmartReport = serde_json::from_str(json_str).ok()?;
-  report.smart_status?.passed
+#[derive(Deserialize, Debug, PartialEq, Eq, Default)]
+pub struct Temperature {
+  #[serde(default)]
+  pub current: u64,
 }
 
-/// given a device path it will try to get the SMART data about it returning true/false to indicate healthy or not otherwise it returns None
-pub fn get_smart_data(device_path: &str) -> Option<bool> {
+#[derive(Deserialize, Debug, PartialEq, Eq)]
+pub struct SmartReport {
+  pub smart_status: SmartStatus,
+  #[serde(default)]
+  pub power_on_time: PowerOnTime,
+  #[serde(default)]
+  pub temperature: Temperature,
+}
+
+/// Parse smartctl JSON output string to extract SMART report
+fn parse_smart_report(json_str: &str) -> Option<SmartReport> {
+  serde_json::from_str(json_str).ok()
+}
+
+/// given a device path it will try to get the SMART data about a disk
+pub fn get_smart_data(device_path: &str) -> Option<SmartReport> {
   let output = Command::new("smartctl")
-    .args(["-H", device_path, "-j"])
+    .args(["-a", "-j", device_path])
     .output()
     .ok()?;
   if output.status.success() || !output.stdout.is_empty() {
     let json_str = String::from_utf8_lossy(&output.stdout);
-    return parse_smart_status(&json_str);
+    return parse_smart_report(&json_str);
   }
   None
 }
@@ -87,51 +102,52 @@ mod tests {
   use super::*;
 
   #[test]
-  fn test_parse_healthy_drive() {
+  fn test_parse_healthy_drive_full_metrics() {
     let json = r#"{
-      "smart_status": {
-        "passed": true
-      }
+      "smart_status": { "passed": true },
+      "power_on_time": { "hours": 14200 },
+      "temperature": { "current": 34 }
     }"#;
-    assert_eq!(parse_smart_status(json), Some(true));
+    assert_eq!(
+      parse_smart_report(json),
+      Some(SmartReport {
+        smart_status: SmartStatus { passed: true },
+        power_on_time: PowerOnTime { hours: 14200 },
+        temperature: Temperature { current: 34 },
+      })
+    );
+  }
+
+  #[test]
+  fn test_parse_missing_optional_fields() {
+    let json = r#"{
+      "smart_status": { "passed": true }
+    }"#;
+    assert_eq!(
+      parse_smart_report(json),
+      Some(SmartReport {
+        smart_status: SmartStatus { passed: true },
+        power_on_time: PowerOnTime { hours: 0 },
+        temperature: Temperature { current: 0 },
+      })
+    );
   }
 
   #[test]
   fn test_parse_failing_drive() {
     let json = r#"{
-      "smart_status": {
-        "passed": false
-      }
+      "smart_status": { "passed": false },
+      "power_on_time": { "hours": 50000 },
+      "temperature": { "current": 55 }
     }"#;
-    assert_eq!(parse_smart_status(json), Some(false));
+    let report = parse_smart_report(json).unwrap();
+    assert!(!report.smart_status.passed);
   }
 
   #[test]
-  fn test_parse_nvme_drive() {
-    let json = r#"{
-      "smart_status": {
-        "passed": true,
-        "nvme": {
-          "value": 0
-        }
-      }
-    }"#;
-    assert_eq!(parse_smart_status(json), Some(true));
-  }
-
-  #[test]
-  fn test_parse_unsupported_or_missing_smart() {
-    let json = r#"{
-      "device": {
-        "name": "/dev/loop0",
-        "type": "loop"
-      }
-    }"#;
-    assert_eq!(parse_smart_status(json), None);
-  }
-
-  #[test]
-  fn test_parse_invalid_json() {
-    assert_eq!(parse_smart_status("invalid json string"), None);
+  fn test_parse_unsupported_or_invalid() {
+    let json = r#"{ "device": { "name": "/dev/loop0" } }"#;
+    assert_eq!(parse_smart_report(json), None);
+    assert_eq!(parse_smart_report("invalid json"), None);
   }
 }

--- a/bin/periphery/src/stats/mod.rs
+++ b/bin/periphery/src/stats/mod.rs
@@ -7,8 +7,13 @@ use komodo_client::entities::stats::{
 };
 use sysinfo::{ProcessRefreshKind, ProcessesToUpdate, System};
 
-use crate::{config::periphery_config, state::stats_client};
+use crate::{
+  config::periphery_config,
+  state::stats_client,
+  stats::disk::{get_smart_data, volume_to_device_mapper},
+};
 
+mod disk;
 mod mem;
 
 /// This should be called before starting the server in main.rs.
@@ -146,11 +151,15 @@ impl StatsClient {
           disk.file_system().to_string_lossy().to_string();
         let disk_total = disk.total_space() as f64 / BYTES_PER_GB;
         let disk_free = disk.available_space() as f64 / BYTES_PER_GB;
+        let real_path =
+          volume_to_device_mapper(&disk.name().to_string_lossy())
+            .unwrap_or(disk.name().to_string_lossy().to_string());
         SingleDiskUsage {
           mount: disk.mount_point().to_owned(),
           used_gb: disk_total - disk_free,
           total_gb: disk_total,
           file_system,
+          healthy: get_smart_data(&real_path),
         }
       })
       .collect()

--- a/bin/periphery/src/stats/mod.rs
+++ b/bin/periphery/src/stats/mod.rs
@@ -154,12 +154,23 @@ impl StatsClient {
         let real_path =
           volume_to_device_mapper(&disk.name().to_string_lossy())
             .unwrap_or(disk.name().to_string_lossy().to_string());
+        let mut healthy = None;
+        let mut power_on_hours = 0;
+        let mut temperature = 0;
+        if let Some(smart_data) = get_smart_data(&real_path) {
+          healthy = Some(smart_data.smart_status.passed);
+          power_on_hours = smart_data.power_on_time.hours;
+          temperature = smart_data.temperature.current;
+        }
+
         SingleDiskUsage {
           mount: disk.mount_point().to_owned(),
           used_gb: disk_total - disk_free,
           total_gb: disk_total,
           file_system,
-          healthy: get_smart_data(&real_path),
+          healthy,
+          power_on_hours,
+          temperature,
         }
       })
       .collect()

--- a/client/core/rs/src/entities/alert.rs
+++ b/client/core/rs/src/entities/alert.rs
@@ -155,6 +155,10 @@ pub enum AlertData {
     used_gb: f64,
     /// The total size of the disk in GB
     total_gb: f64,
+    /// The last SMART test results
+    healthy: Option<bool>,
+    /// The current temperature
+    temperature: Option<u64>,
   },
 
   /// A server has a version mismatch with the core.

--- a/client/core/rs/src/entities/stats.rs
+++ b/client/core/rs/src/entities/stats.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 use serde::{Deserialize, Serialize};
 use typeshare::typeshare;
 
-use crate::entities::{I64, Timelength};
+use crate::entities::{I64, Timelength, U64};
 
 /// System information of a server
 #[typeshare]
@@ -232,6 +232,10 @@ pub struct SingleDiskUsage {
   pub total_gb: f64,
   /// SMART health status
   pub healthy: Option<bool>,
+  /// The amount of hours the device has been running
+  pub power_on_hours: U64,
+  /// The current temperature of the drive
+  pub temperature: U64,
 }
 
 /// Info for network interface usage.

--- a/client/core/rs/src/entities/stats.rs
+++ b/client/core/rs/src/entities/stats.rs
@@ -230,6 +230,8 @@ pub struct SingleDiskUsage {
   pub used_gb: f64,
   /// Total size of the disk in GB
   pub total_gb: f64,
+  /// SMART health status
+  pub healthy: Option<bool>,
 }
 
 /// Info for network interface usage.

--- a/client/core/ts/src/types.ts
+++ b/client/core/ts/src/types.ts
@@ -2881,6 +2881,8 @@ export interface SystemLoadAverage {
 	fifteen: number;
 }
 
+export type U64 = number;
+
 /** Info for a single disk mounted on the system. */
 export interface SingleDiskUsage {
 	/** The mount point of the disk */
@@ -2893,6 +2895,10 @@ export interface SingleDiskUsage {
 	total_gb: number;
 	/** SMART health status */
 	healthy?: boolean;
+	/** The amount of hours the device has been running */
+	power_on_hours: U64;
+	/** The current temperature of the drive */
+	temperature: U64;
 }
 
 /** Realtime system stats data. */
@@ -3646,8 +3652,6 @@ export enum SwarmState {
 	/** Unknown case */
 	Unknown = "Unknown",
 }
-
-export type U64 = number;
 
 /** The version number of the object such as node, service, etc. This is needed to avoid conflicting writes. The client must send the version number along with the modified specification when updating these objects.  This approach ensures safe concurrency and determinism in that the change on the object may not be applied if the version number has changed from the last read. In other words, if two update requests specify the same base version, only one of the requests can succeed. As a result, two separate update requests that happen at the same time will not unintentionally overwrite each other. */
 export interface ObjectVersion {

--- a/client/core/ts/src/types.ts
+++ b/client/core/ts/src/types.ts
@@ -2891,6 +2891,8 @@ export interface SingleDiskUsage {
 	used_gb: number;
 	/** Total size of the disk in GB */
 	total_gb: number;
+	/** SMART health status */
+	healthy?: boolean;
 }
 
 /** Realtime system stats data. */

--- a/ui/src/resources/server/stats/disks.tsx
+++ b/ui/src/resources/server/stats/disks.tsx
@@ -2,7 +2,7 @@ import { ICONS } from "@/lib/icons";
 import { DataTable, SortableHeader } from "mogh_ui";
 import { Section } from "mogh_ui";
 import { ShowHideButton } from "mogh_ui";
-import { Group, Text } from "@mantine/core";
+import { Badge, Group, Text } from "@mantine/core";
 import { useLocalStorage } from "@mantine/hooks";
 import { Types } from "komodo_client";
 
@@ -87,6 +87,19 @@ export default function ServerDisks({
                 <>{row.original.percentage.toFixed(2)}% Full</>
               ),
             },
+            {
+               header: "Health",
+               cell: ({ row }) => {
+                 const healthy = row.original.healthy;
+                 if (healthy === true) {
+                   return <Badge color="green">Passed</Badge>;
+                 }
+                 if (healthy === false) {
+                   return <Badge color="red">Failed</Badge>;
+                 }
+                 return <Text c="dimmed" size="sm">N/A</Text>;
+               },
+             }
           ]}
         />
       )}

--- a/ui/src/resources/server/stats/disks.tsx
+++ b/ui/src/resources/server/stats/disks.tsx
@@ -2,7 +2,7 @@ import { ICONS } from "@/lib/icons";
 import { DataTable, SortableHeader } from "mogh_ui";
 import { Section } from "mogh_ui";
 import { ShowHideButton } from "mogh_ui";
-import { Badge, Group, Text } from "@mantine/core";
+import { Badge, Group, Text, Tooltip } from "@mantine/core";
 import { useLocalStorage } from "@mantine/hooks";
 import { Types } from "komodo_client";
 
@@ -91,11 +91,28 @@ export default function ServerDisks({
                header: "Health",
                cell: ({ row }) => {
                  const healthy = row.original.healthy;
+                 const hours = row.original.power_on_hours;
+                 const temperature = row.original.temperature;
+
+                 const label = `Power-on Time: ${hours} hours (${(hours / 24 / 365).toFixed(1)} years)\nTemperature: ${temperature}ºC`;
+
                  if (healthy === true) {
-                   return <Badge color="green">Passed</Badge>;
+                   return (
+                     <Tooltip label={label} withArrow position="top" style={{ whiteSpace: 'pre-line' }}>
+                       <Badge color="green" style={{ cursor: "pointer" }}>
+                         Passed
+                       </Badge>
+                     </Tooltip>
+                   );
                  }
                  if (healthy === false) {
-                   return <Badge color="red">Failed</Badge>;
+                   return (
+                     <Tooltip label={label} withArrow position="top" style={{ whiteSpace: 'pre-line' }}>
+                       <Badge color="red" style={{ cursor: "pointer" }}>
+                         Failed
+                       </Badge>
+                     </Tooltip>
+                   );
                  }
                  return <Text c="dimmed" size="sm">N/A</Text>;
                },


### PR DESCRIPTION
This PR is a basic implementation of S.M.A.R.T status report by showing a badge in the list of drives
<img width="2205" height="240" alt="image" src="https://github.com/user-attachments/assets/5faaef0c-8ec1-45e6-97bf-5bfb46ec8d27" />
By having this status a new alert could also be implemented so if a device starts to fail it send alerts about it.
In order for this to work the docker compose needs to have access to the devices to check its health, this can be done by enabling [`SYS_RAWIO`](https://docs.docker.com/engine/containers/run/#:~:text=SYS%5FRAWIO,2%29%29%2E) or setting the container as privileged.
Also the device needs to be added in the devices property like this:
```yml
    devices:
      - /dev/nvme0n1
``` 
This is just an initial implementation on how the data could be gathered, I have not found another way to it with less privileges, other monitoring tools like [scrutiny](https://github.com/AnalogJ/scrutiny/blob/master/docker/example.hubspoke.docker-compose.yml) require same permissions. The current state of the PR only reports healthy or not and it does not trigger any alerts.
In the case the container doesn't have enough permissions the health will just show N/A
