### PR TITLE
Use expected komodo database name in example restore compose

### DIFF
--- a/docsite/docs/setup/backup.md
+++ b/docsite/docs/setup/backup.md
@@ -102,7 +102,7 @@ services:
       KOMODO_CLI_DATABASE_TARGET_ADDRESS: komodo.example.com:27017
       KOMODO_CLI_DATABASE_TARGET_USERNAME: <db username>
       KOMODO_CLI_DATABASE_TARGET_PASSWORD: <db password>
-      KOMODO_CLI_DATABASE_TARGET_DB_NAME: komodo-restore
+      KOMODO_CLI_DATABASE_TARGET_DB_NAME: komodo
 ```
 
 :::warning


### PR DESCRIPTION
I originally tried a restore with the db name `komodo-restore`, only to see nothing was restored in the GUI. When I change to `komodo`, everything is restored as expected.