### PR TITLE
Add an optional, user-set execution timeout to Actions

### DIFF
--- a/bin/core/src/api/execute/action.rs
+++ b/bin/core/src/api/execute/action.rs
@@ -2,6 +2,7 @@ use std::{
   collections::HashSet,
   path::{Path, PathBuf},
   sync::OnceLock,
+  time::Duration,
 };
 
 use anyhow::Context as _;
@@ -133,6 +134,10 @@ impl Resolve<ExecuteArgs> for RunAction {
 
     let mut update = update.clone();
 
+    let timeout = (action.config.execution_timeout > 0).then(|| {
+      Duration::from_secs(action.config.execution_timeout as u64)
+    });
+
     update_update(update.clone()).await?;
 
     let default_args = parse_action_arguments(
@@ -219,7 +224,7 @@ impl Resolve<ExecuteArgs> for RunAction {
           "deno run --allow-all{https_cert_flag}{reload} {}",
           path.display()
         ),
-        CommandOptions::default().cancel(cancel),
+        CommandOptions::default().cancel(cancel).timeout(timeout),
       )
       .await;
 

--- a/client/core/rs/src/entities/action.rs
+++ b/client/core/rs/src/entities/action.rs
@@ -162,6 +162,13 @@ pub struct ActionConfig {
   #[builder(default)]
   pub reload_deno_deps: bool,
 
+  /// Maximum seconds the Action may run before its process group is
+  /// killed and the run failed. 0 or below means no timeout.
+  #[serde(default = "default_execution_timeout")]
+  #[builder(default = "default_execution_timeout()")]
+  #[partial_default(default_execution_timeout())]
+  pub execution_timeout: i32,
+
   /// Typescript file contents using pre-initialized `komodo` client.
   /// Supports variable / secret interpolation.
   #[serde(default, deserialize_with = "file_contents_deserializer")]
@@ -204,6 +211,10 @@ fn default_run_at_startup() -> bool {
   false
 }
 
+fn default_execution_timeout() -> i32 {
+  0
+}
+
 fn default_webhook_enabled() -> bool {
   true
 }
@@ -227,6 +238,7 @@ impl Default for ActionConfig {
       webhook_enabled: default_webhook_enabled(),
       webhook_secret: Default::default(),
       reload_deno_deps: Default::default(),
+      execution_timeout: default_execution_timeout(),
       arguments_format: Default::default(),
       file_contents: Default::default(),
       arguments: Default::default(),

--- a/client/core/rs/src/entities/action.rs
+++ b/client/core/rs/src/entities/action.rs
@@ -162,8 +162,7 @@ pub struct ActionConfig {
   #[builder(default)]
   pub reload_deno_deps: bool,
 
-  /// Maximum seconds the Action may run before its process group is
-  /// killed and the run failed. 0 or below means no timeout.
+  /// Seconds before a running Action is killed. 0 or below means no timeout.
   #[serde(default = "default_execution_timeout")]
   #[builder(default = "default_execution_timeout()")]
   #[partial_default(default_execution_timeout())]

--- a/client/core/ts/src/types.ts
+++ b/client/core/ts/src/types.ts
@@ -121,6 +121,11 @@ export interface ActionConfig {
 	 */
 	reload_deno_deps?: boolean;
 	/**
+	 * Maximum seconds the Action may run before its process group is
+	 * killed and the run failed. 0 or below means no timeout.
+	 */
+	execution_timeout: number;
+	/**
 	 * Typescript file contents using pre-initialized `komodo` client.
 	 * Supports variable / secret interpolation.
 	 */

--- a/client/core/ts/src/types.ts
+++ b/client/core/ts/src/types.ts
@@ -120,10 +120,7 @@ export interface ActionConfig {
 	 * this can usually be kept false outside of development.
 	 */
 	reload_deno_deps?: boolean;
-	/**
-	 * Maximum seconds the Action may run before its process group is
-	 * killed and the run failed. 0 or below means no timeout.
-	 */
+	/** Seconds before a running Action is killed. 0 or below means no timeout. */
 	execution_timeout: number;
 	/**
 	 * Typescript file contents using pre-initialized `komodo` client.

--- a/ui/public/schema/resources.json
+++ b/ui/public/schema/resources.json
@@ -5042,6 +5042,14 @@
             "null"
           ]
         },
+        "execution_timeout": {
+          "description": "Maximum seconds the Action may run before its process group is\nkilled and the run failed. 0 or below means no timeout.",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "int32"
+        },
         "file_contents": {
           "description": "Typescript file contents using pre-initialized `komodo` client.\nSupports variable / secret interpolation.",
           "type": [

--- a/ui/public/schema/resources.json
+++ b/ui/public/schema/resources.json
@@ -5043,7 +5043,7 @@
           ]
         },
         "execution_timeout": {
-          "description": "Maximum seconds the Action may run before its process group is\nkilled and the run failed. 0 or below means no timeout.",
+          "description": "Seconds before a running Action is killed. 0 or below means no timeout.",
           "type": [
             "integer",
             "null"

--- a/ui/src/resources/action/config.tsx
+++ b/ui/src/resources/action/config.tsx
@@ -1,6 +1,7 @@
 import { Anchor, Group, Select, Stack, Text, TextInput } from "@mantine/core";
 import { useLocalStorage } from "@mantine/hooks";
-import { useState } from "react";
+import { notifications } from "@mantine/notifications";
+import { useEffect, useState } from "react";
 import { Types } from "komodo_client";
 import {
   usePermissions,
@@ -137,6 +138,19 @@ export default function ActionConfig({ id }: { id: string }) {
               failure_alert: {
                 description: "Send an alert any time the Action fails",
               },
+            },
+          },
+          {
+            label: "Timeout",
+            labelHidden: true,
+            fields: {
+              execution_timeout: (execution_timeout, set) => (
+                <ExecutionTimeout
+                  arg={execution_timeout}
+                  set={set}
+                  disabled={disabled}
+                />
+              ),
             },
           },
           {
@@ -295,6 +309,57 @@ export default function ActionConfig({ id }: { id: string }) {
         ],
       }}
     />
+  );
+}
+
+function ExecutionTimeout({
+  arg,
+  set,
+  disabled,
+}: {
+  arg: number;
+  set: (input: Partial<Types.ActionConfig>) => void;
+  disabled: boolean;
+}) {
+  const [input, setInput] = useState(arg.toString());
+  useEffect(() => {
+    setInput(arg.toString());
+  }, [arg]);
+  // Integral and within i32, matching the server field.
+  const valid = (value: string) => {
+    const num = Number(value);
+    return Number.isInteger(num) && num >= -2147483648 && num <= 2147483647;
+  };
+  const error = valid(input)
+    ? undefined
+    : "Timeout must be a whole number of seconds";
+  return (
+    <ConfigItem
+      label="Execution timeout"
+      description="Maximum time the Action may run before its process group is killed and the run is failed. 0 or below disables the timeout."
+    >
+      <Group gap="xs">
+        <TextInput
+          w={100}
+          placeholder="time in seconds"
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          onBlur={(e) => {
+            if (valid(e.target.value)) {
+              set({ execution_timeout: Number(e.target.value) });
+            } else {
+              notifications.show({
+                message: "Execution timeout must be a whole number of seconds",
+                color: "red",
+              });
+            }
+          }}
+          error={error}
+          disabled={disabled}
+        />
+        seconds
+      </Group>
+    </ConfigItem>
   );
 }
 

--- a/ui/src/resources/action/config.tsx
+++ b/ui/src/resources/action/config.tsx
@@ -325,7 +325,6 @@ function ExecutionTimeout({
   useEffect(() => {
     setInput(arg.toString());
   }, [arg]);
-  // Integral and within i32, matching the server field.
   const valid = (value: string) => {
     const num = Number(value);
     return Number.isInteger(num) && num >= -2147483648 && num <= 2147483647;


### PR DESCRIPTION
## What this is for

A ceiling a user can set on how long one Action may run, so a script that is buggy, looping, or waiting on something that never arrives gets stopped and failed instead of running until somebody notices. It is a control for the person writing the Action, not a fix for anything in Komodo.

The fix side is #1564, which closes the channel leaks and the missing cancellation in terminal execution and stops a killed command's output being discarded. They compose: without #1564 a timeout here produces an empty log; with it you get everything the script printed before the kill.

Related to #1392, whose first item asks for an optional timeout on the shell command function. This applies the same shape at the Action layer, with the caveat that an Action is a deliberately long-running case rather than the fast calls that issue has in mind, which is why I have not picked a default.

## Change

`ActionConfig.execution_timeout`, in seconds, `0` or below meaning no timeout. Passed to the existing `CommandOptions::timeout`, so the process group is killed and the run is failed, which fires `ActionFailed`.

Defaults to `0`, so upgrading is a no-op: absent Mongo fields deserialize to 0, omitted sync TOML shows no drift, and with `timeout = None` the `select!` is the pre-change path. Follows `DeploymentConfig.termination_timeout` throughout: the attribute triple, `i32` seconds, and the UI control is that one with the label and bounds changed.

## Known limits

- A kill is SIGKILL to the process group, so the Action's `finally` never runs and a terminal the script created on a server is not deleted by the script itself. #1564 stops the forwarding task and the response channel leaking on that path; the PTY still waits for normal cleanup. I am not proposing SIGTERM escalation: unhandled SIGTERM runs no JS in Deno, so the cleanup would not happen anyway.
- Adding a public field to `ActionConfig` is semver-major for downstream literal constructors.

## Testing

`cargo check -p komodo_client -p komodo_core`, `cargo test -p command`, `cargo fmt --check` and `tsc` on the touched TS file, all clean. `types.ts` regenerated with typeshare 1.13.4. The `resources.json` field was added by hand, because a full regen also sweeps in unrelated drift (`custom_name`, `tags`) the committed schema is missing.

Not tested end to end against a running Core; the kill path is verified from `lib/command`'s own tests plus a local probe.
