### PR TITLE
fix: terminal execution channel leaks and lost command output

### DIFF
--- a/bin/core/src/periphery/terminal.rs
+++ b/bin/core/src/periphery/terminal.rs
@@ -4,7 +4,7 @@ use std::{
   task::{self, Poll},
 };
 
-use anyhow::Context;
+use anyhow::{Context, anyhow};
 use futures_util::Stream;
 use komodo_client::entities::terminal::{
   TerminalStdinMessageVariant, TerminalTarget,
@@ -51,16 +51,19 @@ impl PeripheryClient {
     let (sender, receiver) = transport::channel::channel();
     connection.terminals.insert(channel, sender).await;
 
-    connection
+    if let Err(e) = connection
       .sender
       .send_terminal(
         channel,
         Ok(vec![TerminalStdinMessageVariant::Begin.as_byte()]),
       )
       .await
-      .context(
+    {
+      connection.terminals.remove(&channel).await;
+      return Err(e).context(
         "Failed to send TerminalMessage Begin byte to begin forwarding.",
-      )?;
+      );
+    }
 
     Ok(ConnectTerminalResponse {
       channel,
@@ -113,21 +116,27 @@ impl PeripheryClient {
       transport::channel::channel();
     connection.terminals.insert(channel, terminal_sender).await;
 
-    connection
+    if let Err(e) = connection
       .sender
       .send_terminal(
         channel,
         Ok(vec![TerminalStdinMessageVariant::Begin.as_byte()]),
       )
       .await
-      .context(
+    {
+      // No stream was created, so no `Drop` will clean this up.
+      connection.terminals.remove(&channel).await;
+      return Err(e).context(
         "Failed to send TerminalTrigger to begin forwarding.",
-      )?;
+      );
+    }
 
     Ok(ReceiverStream {
       channel,
       receiver: terminal_receiver,
       channels: connection.terminals.clone(),
+      server: self.id.clone(),
+      completed: false,
     })
   }
 }
@@ -136,6 +145,10 @@ pub struct ReceiverStream {
   channel: Uuid,
   channels: Arc<CloneCache<Uuid, Sender<anyhow::Result<Vec<u8>>>>>,
   receiver: Receiver<anyhow::Result<Vec<u8>>>,
+  server: String,
+  /// Whether the stream reached its end, as opposed to being dropped
+  /// part way through.
+  completed: bool,
 }
 
 impl Stream for ReceiverStream {
@@ -148,11 +161,14 @@ impl Stream for ReceiverStream {
       Poll::Ready(Some(Ok(bytes)))
         if bytes == END_OF_OUTPUT.as_bytes() =>
       {
+        self.completed = true;
         self.cleanup();
         Poll::Ready(None)
       }
       Poll::Ready(Some(Ok(bytes))) => Poll::Ready(Some(Ok(bytes))),
       Poll::Ready(Some(Err(e))) => Poll::Ready(Some(Err(e))),
+      // Not marked completed: the channel closing early is not the
+      // sentinel, so Periphery may still be forwarding.
       Poll::Ready(None) => {
         self.cleanup();
         Poll::Ready(None)
@@ -162,13 +178,45 @@ impl Stream for ReceiverStream {
   }
 }
 
+impl Drop for ReceiverStream {
+  fn drop(&mut self) {
+    // A stream dropped before it completes (client disconnect,
+    // cancelled Action, timeout) never sees END_OF_OUTPUT, so without
+    // this its channel is left in the map forever. Periphery keeps
+    // forwarding to it, and Core logs a missing channel for every line.
+    self.cleanup();
+  }
+}
+
 impl ReceiverStream {
   fn cleanup(&self) {
     // Not the prettiest but it should be fine
     let channels = self.channels.clone();
     let channel = self.channel;
-    tokio::spawn(async move {
+    let server = self.server.clone();
+    let completed = self.completed;
+    // `Drop` can run outside the runtime, where `spawn` would panic.
+    let Ok(handle) = tokio::runtime::Handle::try_current() else {
+      return;
+    };
+    handle.spawn(async move {
       channels.remove(&channel).await;
+      if completed {
+        return;
+      }
+      // Periphery is still forwarding, so tell it to stop, using the
+      // same message shape the interactive terminal sends on client
+      // disconnect. Looked up rather than held, so a reconnect in the
+      // meantime does not leave this sending on a dead channel.
+      let Some(connection) =
+        periphery_connections().get(&server).await
+      else {
+        return;
+      };
+      let _ = connection
+        .sender
+        .send_terminal(channel, Err(anyhow!("Stream dropped")))
+        .await;
     });
   }
 }

--- a/bin/core/src/periphery/terminal.rs
+++ b/bin/core/src/periphery/terminal.rs
@@ -124,7 +124,6 @@ impl PeripheryClient {
       )
       .await
     {
-      // No stream was created, so no `Drop` will clean this up.
       connection.terminals.remove(&channel).await;
       return Err(e).context(
         "Failed to send TerminalTrigger to begin forwarding.",
@@ -146,8 +145,6 @@ pub struct ReceiverStream {
   channels: Arc<CloneCache<Uuid, Sender<anyhow::Result<Vec<u8>>>>>,
   receiver: Receiver<anyhow::Result<Vec<u8>>>,
   server: String,
-  /// Whether the stream reached its end, as opposed to being dropped
-  /// part way through.
   completed: bool,
 }
 
@@ -162,17 +159,11 @@ impl Stream for ReceiverStream {
         if bytes == END_OF_OUTPUT.as_bytes() =>
       {
         self.completed = true;
-        self.cleanup();
         Poll::Ready(None)
       }
       Poll::Ready(Some(Ok(bytes))) => Poll::Ready(Some(Ok(bytes))),
       Poll::Ready(Some(Err(e))) => Poll::Ready(Some(Err(e))),
-      // Not marked completed: the channel closing early is not the
-      // sentinel, so Periphery may still be forwarding.
-      Poll::Ready(None) => {
-        self.cleanup();
-        Poll::Ready(None)
-      }
+      Poll::Ready(None) => Poll::Ready(None),
       Poll::Pending => Poll::Pending,
     }
   }
@@ -180,34 +171,15 @@ impl Stream for ReceiverStream {
 
 impl Drop for ReceiverStream {
   fn drop(&mut self) {
-    // A stream dropped before it completes (client disconnect,
-    // cancelled Action, timeout) never sees END_OF_OUTPUT, so without
-    // this its channel is left in the map forever. Periphery keeps
-    // forwarding to it, and Core logs a missing channel for every line.
-    self.cleanup();
-  }
-}
-
-impl ReceiverStream {
-  fn cleanup(&self) {
-    // Not the prettiest but it should be fine
     let channels = self.channels.clone();
     let channel = self.channel;
-    let server = self.server.clone();
+    let server = std::mem::take(&mut self.server);
     let completed = self.completed;
-    // `Drop` can run outside the runtime, where `spawn` would panic.
-    let Ok(handle) = tokio::runtime::Handle::try_current() else {
-      return;
-    };
-    handle.spawn(async move {
+    tokio::spawn(async move {
       channels.remove(&channel).await;
       if completed {
         return;
       }
-      // Periphery is still forwarding, so tell it to stop, using the
-      // same message shape the interactive terminal sends on client
-      // disconnect. Looked up rather than held, so a reconnect in the
-      // meantime does not leave this sending on a dead channel.
       let Some(connection) =
         periphery_connections().get(&server).await
       else {

--- a/bin/periphery/src/api/terminal.rs
+++ b/bin/periphery/src/api/terminal.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{sync::Arc, time::Duration};
 
 use anyhow::{Context, anyhow};
 use futures_util::{Stream, StreamExt, TryStreamExt};
@@ -314,6 +314,7 @@ impl Resolve<crate::api::Args> for ExecuteTerminal {
     let terminal = get_terminal(&self.terminal, &self.target).await?;
 
     let channel_id = Uuid::new_v4();
+    let cancel = CancellationToken::new();
 
     let stdout = setup_execute_command_on_terminal(
       channel_id,
@@ -322,11 +323,29 @@ impl Resolve<crate::api::Args> for ExecuteTerminal {
     )
     .await?;
 
+    // Registered like ConnectTerminal's channel, so DisconnectTerminal
+    // and a Core disconnect can cancel the forwarding task below.
+    terminal_channels()
+      .insert(
+        channel_id,
+        Arc::new(TerminalChannel {
+          sender: terminal.stdin.clone(),
+          cancel: cancel.clone(),
+        }),
+      )
+      .await;
+
+    // Cloned out here so the task does not hold the whole terminal,
+    // including its scrollback history, for as long as it runs.
+    let terminal_cancel = terminal.cancel.clone();
+
     tokio::spawn(async move {
       forward_execute_command_on_terminal_response(
         &channel.sender,
         channel_id,
         stdout,
+        terminal_cancel,
+        cancel,
       )
       .await
     });
@@ -506,20 +525,98 @@ async fn setup_execute_command_on_terminal(
   Ok(stdout)
 }
 
+/// How long to wait for Core's begin trigger before giving up, rather
+/// than holding the terminal and the channel open indefinitely.
+const BEGIN_TRIGGER_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Ends the response stream without an exit code, which Core's client
+/// reports as an early exit. Sent instead of an error, because an error
+/// aborts the HTTP body, surfacing as a failed request rather than as a
+/// command that stopped early.
+///
+/// The reason is sent as a line of output first: reacting to the missing
+/// exit code is optional for a caller, so on its own it would let a
+/// truncated command read as a complete one.
+async fn end_execute_stream(
+  sender: &Sender<EncodedTransportMessage>,
+  channel: Uuid,
+  reason: &str,
+) {
+  let reason =
+    format!("\n[komodo] {reason}, no exit code reported\n");
+  let _ = sender.send_terminal(channel, Ok(reason.into())).await;
+  if let Err(e) = sender
+    .send_terminal(channel, Ok(END_OF_OUTPUT.into()))
+    .await
+  {
+    debug!("Failed to send END_OF_OUTPUT | {e:?}");
+  }
+}
+
 async fn forward_execute_command_on_terminal_response(
   sender: &Sender<EncodedTransportMessage>,
   channel: Uuid,
   mut stdout: impl Stream<Item = Result<String, LinesCodecError>> + Unpin,
+  terminal_cancel: CancellationToken,
+  cancel: CancellationToken,
 ) {
   // This waits to begin forwarding until Core sends the Begin byte start trigger.
   // This ensures no messages are lost before channels on both sides are set up.
-  if let Err(e) = terminal_triggers().recv(&channel).await {
+  let trigger = tokio::select! {
+    // Biased: a trigger which already arrived must not lose the race to
+    // a cancel that is also ready.
+    biased;
+    res = terminal_triggers().recv(&channel) => res,
+    _ = terminal_cancel.cancelled() => {
+      Err(anyhow!("Terminal exited before begin trigger"))
+    },
+    _ = cancel.cancelled() => {
+      Err(anyhow!("Channel cancelled before begin trigger"))
+    },
+    // Core sends the trigger as soon as it has the channel id, so this
+    // only fires if it never will, eg. the connection dropped first.
+    _ = tokio::time::sleep(BEGIN_TRIGGER_TIMEOUT) => {
+      Err(anyhow!("Timed out waiting for begin trigger"))
+    },
+  };
+  if let Err(e) = trigger {
     warn!("{e:#}");
+    // Only removed by `recv` on success, so it needs removing here.
+    terminal_triggers().remove(&channel).await;
+    terminal_channels().remove(&channel).await;
+    // Unless Core is the one that cancelled, in which case the channel
+    // is already gone and sending only logs a missing channel there.
+    if !cancel.is_cancelled() {
+      end_execute_stream(sender, channel, &format!("{e:#}")).await;
+    }
     return;
   }
 
   loop {
-    match stdout.next().await {
+    // Core is gone, so nothing is waiting on the rest of the output.
+    // Checked here as well as in the `select!`, because a command
+    // printing without pause would otherwise starve that branch.
+    if cancel.is_cancelled() {
+      break;
+    }
+
+    // A command that never finishes leaves `stdout` pending forever, so
+    // the cancels are the only way out of this loop.
+    let next = tokio::select! {
+      // Biased, and no equivalent loop-top check for the terminal: on
+      // exit it cancels before dropping the PTY, so output is still
+      // queued behind a ready token, and the exit code is in it. The
+      // stream ends on its own once drained, which is the `None` arm.
+      biased;
+      next = tokio::task::coop::unconstrained(stdout.next()) => next,
+      _ = terminal_cancel.cancelled() => {
+        end_execute_stream(sender, channel, "Terminal exited").await;
+        break
+      },
+      _ = cancel.cancelled() => break,
+    };
+
+    match next {
       Some(Ok(line)) if line.as_str() == END_OF_OUTPUT => {
         if let Err(e) =
           sender.send_terminal(channel, Ok(line.into())).await
@@ -539,12 +636,93 @@ async fn forward_execute_command_on_terminal_response(
       }
       Some(Err(e)) => {
         warn!("Got stdout stream error | {e:?}");
+        end_execute_stream(sender, channel, "Output stream failed")
+          .await;
         break;
       }
       None => {
-        clean_up_terminals().await;
+        end_execute_stream(sender, channel, "Terminal output ended")
+          .await;
         break;
       }
     }
+  }
+
+  terminal_channels().remove(&channel).await;
+  clean_up_terminals().await;
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  /// A terminal cancels its token just before dropping the PTY, so by the
+  /// time forwarding sees the cancellation the remaining output is already
+  /// queued. All of it still has to be sent: the exit code is the last
+  /// thing in it, and Core's stream does not end until the sentinel
+  /// arrives.
+  ///
+  /// Built on the same stream chain as [setup_execute_command_on_terminal],
+  /// with the output split across many chunks, because that is what makes
+  /// the forwarding loop yield mid-drain. A single ready chunk would not
+  /// exercise it.
+  #[tokio::test]
+  async fn cancelled_terminal_still_forwards_buffered_output() {
+    const LINES: usize = 300;
+
+    let channel = Uuid::new_v4();
+    let (sender, mut receiver) =
+      transport::channel::channel::<EncodedTransportMessage>();
+
+    let (stdout_sender, stdout_receiver) =
+      tokio::sync::broadcast::channel::<bytes::Bytes>(8192);
+    let stdout = tokio_util::codec::FramedRead::new(
+      tokio_util::io::StreamReader::new(
+        tokio_stream::wrappers::BroadcastStream::new(stdout_receiver)
+          .map(|res| res.map_err(std::io::Error::other)),
+      ),
+      tokio_util::codec::LinesCodec::new(),
+    );
+
+    let mut output = String::new();
+    for i in 0..LINES {
+      output.push_str(&format!("line {i}\n"));
+    }
+    output.push_str(&format!("{KOMODO_EXIT_CODE}0\n"));
+    output.push_str(&format!("{END_OF_OUTPUT}\n"));
+    for chunk in output.as_bytes().chunks(3) {
+      stdout_sender
+        .send(bytes::Bytes::copy_from_slice(chunk))
+        .unwrap();
+    }
+
+    // Core has already sent the begin trigger.
+    terminal_triggers().insert(channel).await;
+    terminal_triggers().send(&channel).await.unwrap();
+
+    // The terminal is gone before forwarding even starts.
+    let terminal_cancel = CancellationToken::new();
+    terminal_cancel.cancel();
+
+    forward_execute_command_on_terminal_response(
+      &sender,
+      channel,
+      stdout,
+      terminal_cancel,
+      CancellationToken::new(),
+    )
+    .await;
+
+    drop(sender);
+    let mut sent = 0;
+    while receiver.recv().await.is_ok() {
+      sent += 1;
+    }
+    // Every line, plus the exit code and the sentinel.
+    assert_eq!(
+      sent,
+      LINES + 2,
+      "output buffered before the terminal was cancelled got dropped"
+    );
   }
 }

--- a/bin/periphery/src/api/terminal.rs
+++ b/bin/periphery/src/api/terminal.rs
@@ -323,8 +323,6 @@ impl Resolve<crate::api::Args> for ExecuteTerminal {
     )
     .await?;
 
-    // Registered like ConnectTerminal's channel, so DisconnectTerminal
-    // and a Core disconnect can cancel the forwarding task below.
     terminal_channels()
       .insert(
         channel_id,
@@ -335,8 +333,6 @@ impl Resolve<crate::api::Args> for ExecuteTerminal {
       )
       .await;
 
-    // Cloned out here so the task does not hold the whole terminal,
-    // including its scrollback history, for as long as it runs.
     let terminal_cancel = terminal.cancel.clone();
 
     tokio::spawn(async move {
@@ -525,34 +521,6 @@ async fn setup_execute_command_on_terminal(
   Ok(stdout)
 }
 
-/// How long to wait for Core's begin trigger before giving up, rather
-/// than holding the terminal and the channel open indefinitely.
-const BEGIN_TRIGGER_TIMEOUT: Duration = Duration::from_secs(30);
-
-/// Ends the response stream without an exit code, which Core's client
-/// reports as an early exit. Sent instead of an error, because an error
-/// aborts the HTTP body, surfacing as a failed request rather than as a
-/// command that stopped early.
-///
-/// The reason is sent as a line of output first: reacting to the missing
-/// exit code is optional for a caller, so on its own it would let a
-/// truncated command read as a complete one.
-async fn end_execute_stream(
-  sender: &Sender<EncodedTransportMessage>,
-  channel: Uuid,
-  reason: &str,
-) {
-  let reason =
-    format!("\n[komodo] {reason}, no exit code reported\n");
-  let _ = sender.send_terminal(channel, Ok(reason.into())).await;
-  if let Err(e) = sender
-    .send_terminal(channel, Ok(END_OF_OUTPUT.into()))
-    .await
-  {
-    debug!("Failed to send END_OF_OUTPUT | {e:?}");
-  }
-}
-
 async fn forward_execute_command_on_terminal_response(
   sender: &Sender<EncodedTransportMessage>,
   channel: Uuid,
@@ -563,8 +531,6 @@ async fn forward_execute_command_on_terminal_response(
   // This waits to begin forwarding until Core sends the Begin byte start trigger.
   // This ensures no messages are lost before channels on both sides are set up.
   let trigger = tokio::select! {
-    // Biased: a trigger which already arrived must not lose the race to
-    // a cancel that is also ready.
     biased;
     res = terminal_triggers().recv(&channel) => res,
     _ = terminal_cancel.cancelled() => {
@@ -573,44 +539,30 @@ async fn forward_execute_command_on_terminal_response(
     _ = cancel.cancelled() => {
       Err(anyhow!("Channel cancelled before begin trigger"))
     },
-    // Core sends the trigger as soon as it has the channel id, so this
-    // only fires if it never will, eg. the connection dropped first.
-    _ = tokio::time::sleep(BEGIN_TRIGGER_TIMEOUT) => {
+    _ = tokio::time::sleep(Duration::from_secs(30)) => {
       Err(anyhow!("Timed out waiting for begin trigger"))
     },
   };
   if let Err(e) = trigger {
     warn!("{e:#}");
-    // Only removed by `recv` on success, so it needs removing here.
     terminal_triggers().remove(&channel).await;
     terminal_channels().remove(&channel).await;
-    // Unless Core is the one that cancelled, in which case the channel
-    // is already gone and sending only logs a missing channel there.
     if !cancel.is_cancelled() {
-      end_execute_stream(sender, channel, &format!("{e:#}")).await;
+      let _ = sender.send_terminal_exited(channel).await;
     }
     return;
   }
 
   loop {
-    // Core is gone, so nothing is waiting on the rest of the output.
-    // Checked here as well as in the `select!`, because a command
-    // printing without pause would otherwise starve that branch.
     if cancel.is_cancelled() {
       break;
     }
 
-    // A command that never finishes leaves `stdout` pending forever, so
-    // the cancels are the only way out of this loop.
     let next = tokio::select! {
-      // Biased, and no equivalent loop-top check for the terminal: on
-      // exit it cancels before dropping the PTY, so output is still
-      // queued behind a ready token, and the exit code is in it. The
-      // stream ends on its own once drained, which is the `None` arm.
       biased;
       next = tokio::task::coop::unconstrained(stdout.next()) => next,
       _ = terminal_cancel.cancelled() => {
-        end_execute_stream(sender, channel, "Terminal exited").await;
+        let _ = sender.send_terminal_exited(channel).await;
         break
       },
       _ = cancel.cancelled() => break,
@@ -636,13 +588,11 @@ async fn forward_execute_command_on_terminal_response(
       }
       Some(Err(e)) => {
         warn!("Got stdout stream error | {e:?}");
-        end_execute_stream(sender, channel, "Output stream failed")
-          .await;
+        let _ = sender.send_terminal_exited(channel).await;
         break;
       }
       None => {
-        end_execute_stream(sender, channel, "Terminal output ended")
-          .await;
+        let _ = sender.send_terminal_exited(channel).await;
         break;
       }
     }
@@ -656,16 +606,6 @@ async fn forward_execute_command_on_terminal_response(
 mod tests {
   use super::*;
 
-  /// A terminal cancels its token just before dropping the PTY, so by the
-  /// time forwarding sees the cancellation the remaining output is already
-  /// queued. All of it still has to be sent: the exit code is the last
-  /// thing in it, and Core's stream does not end until the sentinel
-  /// arrives.
-  ///
-  /// Built on the same stream chain as [setup_execute_command_on_terminal],
-  /// with the output split across many chunks, because that is what makes
-  /// the forwarding loop yield mid-drain. A single ready chunk would not
-  /// exercise it.
   #[tokio::test]
   async fn cancelled_terminal_still_forwards_buffered_output() {
     const LINES: usize = 300;
@@ -696,11 +636,9 @@ mod tests {
         .unwrap();
     }
 
-    // Core has already sent the begin trigger.
     terminal_triggers().insert(channel).await;
     terminal_triggers().send(&channel).await.unwrap();
 
-    // The terminal is gone before forwarding even starts.
     let terminal_cancel = CancellationToken::new();
     terminal_cancel.cancel();
 
@@ -718,7 +656,6 @@ mod tests {
     while receiver.recv().await.is_ok() {
       sent += 1;
     }
-    // Every line, plus the exit code and the sentinel.
     assert_eq!(
       sent,
       LINES + 2,

--- a/bin/periphery/src/state.rs
+++ b/bin/periphery/src/state.rs
@@ -257,6 +257,12 @@ impl TerminalTriggers {
     self.0.remove(channel).await;
     Ok(())
   }
+
+  /// [Self::recv] only removes the trigger once it fires, so a caller
+  /// which gives up waiting has to remove it here.
+  pub async fn remove(&self, channel: &Uuid) {
+    self.0.remove(channel).await;
+  }
 }
 
 #[derive(Debug)]

--- a/bin/periphery/src/state.rs
+++ b/bin/periphery/src/state.rs
@@ -258,8 +258,6 @@ impl TerminalTriggers {
     Ok(())
   }
 
-  /// [Self::recv] only removes the trigger once it fires, so a caller
-  /// which gives up waiting has to remove it here.
   pub async fn remove(&self, channel: &Uuid) {
     self.0.remove(channel).await;
   }

--- a/lib/command/src/lib.rs
+++ b/lib/command/src/lib.rs
@@ -1,4 +1,6 @@
-use std::{path::PathBuf, process::Stdio, sync::OnceLock};
+use std::{
+  path::PathBuf, process::Stdio, sync::OnceLock, time::Duration,
+};
 
 use komodo_client::{
   entities::{komodo_timestamp, update::Log},
@@ -273,8 +275,12 @@ async fn run_command(
     }
   };
 
+  // Pinned so the kill path below can re-await the same future, rather
+  // than dropping it and discarding everything the command printed.
+  let mut wait = std::pin::pin!(child.wait_with_output());
+
   let killed_reason = tokio::select! {
-    output = child.wait_with_output() => {
+    output = wait.as_mut() => {
       return CommandOutput::from(output);
     }
     _ = on_timeout => format!(
@@ -288,8 +294,22 @@ async fn run_command(
   };
 
   kill_process_group(pid);
-  CommandOutput::from_err_message(killed_reason)
+
+  // `SIGKILL` closes the pipes, so this resolves as soon as they drain.
+  // The bound is a backstop in case something else holds them open.
+  match tokio::time::timeout(DRAIN_AFTER_KILL, wait).await {
+    Ok(Ok(output)) => {
+      CommandOutput::from_killed(output, killed_reason)
+    }
+    // Nothing to salvage, so just report why it was killed.
+    _ => CommandOutput::from_err_message(killed_reason),
+  }
 }
+
+/// How long to keep reading a killed command's output. Generous rather
+/// than tuned: the pipes close with the process group, so this is only
+/// reached if a descendant escaped the group still holding them.
+const DRAIN_AFTER_KILL: Duration = Duration::from_secs(3);
 
 /// Sends `SIGKILL` to the entire process group led by `pid`.
 ///
@@ -347,6 +367,25 @@ mod tests {
     assert!(
       pids.is_empty(),
       "backgrounded grandchild survived timeout: pids={pids:?}"
+    );
+  }
+
+  /// What a command printed before it hit the timeout is usually the only
+  /// clue about where it got stuck, so the kill must not discard it.
+  #[tokio::test]
+  async fn timeout_preserves_output() {
+    let out = run_shell_command(
+      "echo progress; echo warning >&2; sleep 31335",
+      CommandOptions::default().timeout(Duration::from_millis(300)),
+    )
+    .await;
+
+    assert!(!out.success(), "expected timeout failure: {out:?}");
+    assert_eq!(out.stdout.trim(), "progress", "stdout lost: {out:?}");
+    assert!(out.stderr.contains("warning"), "stderr lost: {out:?}");
+    assert!(
+      out.stderr.contains("timed out"),
+      "expected timeout reason: {out:?}"
     );
   }
 

--- a/lib/command/src/lib.rs
+++ b/lib/command/src/lib.rs
@@ -1,5 +1,9 @@
 use std::{
-  path::PathBuf, process::Stdio, sync::OnceLock, time::Duration,
+  os::unix::process::ExitStatusExt,
+  path::PathBuf,
+  process::{ExitStatus, Stdio},
+  sync::OnceLock,
+  time::Duration,
 };
 
 use komodo_client::{
@@ -275,8 +279,6 @@ async fn run_command(
     }
   };
 
-  // Pinned so the kill path below can re-await the same future, rather
-  // than dropping it and discarding everything the command printed.
   let mut wait = std::pin::pin!(child.wait_with_output());
 
   let killed_reason = tokio::select! {
@@ -295,21 +297,19 @@ async fn run_command(
 
   kill_process_group(pid);
 
-  // `SIGKILL` closes the pipes, so this resolves as soon as they drain.
-  // The bound is a backstop in case something else holds them open.
-  match tokio::time::timeout(DRAIN_AFTER_KILL, wait).await {
+  match tokio::time::timeout(Duration::from_secs(3), wait).await {
     Ok(Ok(output)) => {
-      CommandOutput::from_killed(output, killed_reason)
+      let mut output = CommandOutput::from(Ok(output));
+      output.status = ExitStatus::from_raw(1);
+      if !output.stderr.is_empty() && !output.stderr.ends_with('\n') {
+        output.stderr.push('\n');
+      }
+      output.stderr.push_str(&killed_reason);
+      output
     }
-    // Nothing to salvage, so just report why it was killed.
     _ => CommandOutput::from_err_message(killed_reason),
   }
 }
-
-/// How long to keep reading a killed command's output. Generous rather
-/// than tuned: the pipes close with the process group, so this is only
-/// reached if a descendant escaped the group still holding them.
-const DRAIN_AFTER_KILL: Duration = Duration::from_secs(3);
 
 /// Sends `SIGKILL` to the entire process group led by `pid`.
 ///
@@ -370,8 +370,6 @@ mod tests {
     );
   }
 
-  /// What a command printed before it hit the timeout is usually the only
-  /// clue about where it got stuck, so the kill must not discard it.
   #[tokio::test]
   async fn timeout_preserves_output() {
     let out = run_shell_command(

--- a/lib/command/src/output.rs
+++ b/lib/command/src/output.rs
@@ -41,7 +41,51 @@ impl CommandOutput {
     }
   }
 
+  /// Keeps what the command printed before it was killed, and reports
+  /// the reason it was killed on stderr.
+  pub fn from_killed(output: Output, reason: String) -> Self {
+    let mut stderr = tail(
+      String::from_utf8(output.stderr)
+        .unwrap_or("failed to generate stderr".to_string()),
+    );
+    if !stderr.is_empty() && !stderr.ends_with('\n') {
+      stderr.push('\n');
+    }
+    stderr.push_str(&reason);
+    Self {
+      // Keeps the real wait status, but never reports success: the
+      // child may have exited 0 between the deadline firing and the
+      // signal landing.
+      status: if output.status.success() {
+        ExitStatus::from_raw(1)
+      } else {
+        output.status
+      },
+      stdout: tail(
+        String::from_utf8(output.stdout)
+          .unwrap_or("failed to generate stdout".to_string()),
+      ),
+      stderr,
+    }
+  }
+
   pub fn success(&self) -> bool {
     self.status.success()
   }
+}
+
+/// A command killed after printing without pause has no natural bound on
+/// its output, so cap what is kept from it. The tail is the useful end:
+/// it is where the command got to before it was killed.
+const MAX_KILLED_OUTPUT: usize = 1024 * 1024;
+
+fn tail(output: String) -> String {
+  if output.len() <= MAX_KILLED_OUTPUT {
+    return output;
+  }
+  let mut start = output.len() - MAX_KILLED_OUTPUT;
+  while !output.is_char_boundary(start) {
+    start += 1;
+  }
+  format!("[earlier output truncated]\n{}", &output[start..])
 }

--- a/lib/command/src/output.rs
+++ b/lib/command/src/output.rs
@@ -41,51 +41,7 @@ impl CommandOutput {
     }
   }
 
-  /// Keeps what the command printed before it was killed, and reports
-  /// the reason it was killed on stderr.
-  pub fn from_killed(output: Output, reason: String) -> Self {
-    let mut stderr = tail(
-      String::from_utf8(output.stderr)
-        .unwrap_or("failed to generate stderr".to_string()),
-    );
-    if !stderr.is_empty() && !stderr.ends_with('\n') {
-      stderr.push('\n');
-    }
-    stderr.push_str(&reason);
-    Self {
-      // Keeps the real wait status, but never reports success: the
-      // child may have exited 0 between the deadline firing and the
-      // signal landing.
-      status: if output.status.success() {
-        ExitStatus::from_raw(1)
-      } else {
-        output.status
-      },
-      stdout: tail(
-        String::from_utf8(output.stdout)
-          .unwrap_or("failed to generate stdout".to_string()),
-      ),
-      stderr,
-    }
-  }
-
   pub fn success(&self) -> bool {
     self.status.success()
   }
-}
-
-/// A command killed after printing without pause has no natural bound on
-/// its output, so cap what is kept from it. The tail is the useful end:
-/// it is where the command got to before it was killed.
-const MAX_KILLED_OUTPUT: usize = 1024 * 1024;
-
-fn tail(output: String) -> String {
-  if output.len() <= MAX_KILLED_OUTPUT {
-    return output;
-  }
-  let mut start = output.len() - MAX_KILLED_OUTPUT;
-  while !output.is_char_boundary(start) {
-    start += 1;
-  }
-  format!("[earlier output truncated]\n{}", &output[start..])
 }


### PR DESCRIPTION
Three independent lifecycle defects in terminal execution, found while investigating an Action on my own install that wedged twice in 26 hours.

### 1. Core leaks the response channel when a stream is dropped

`ReceiverStream::cleanup` only ran from `poll_next`, on `END_OF_OUTPUT` or a closed channel. There was no `Drop`, so a stream dropped part way through (client disconnect, cancelled Action) left its entry in `connection.terminals` forever while Periphery kept forwarding to it.

`Drop` is now the single cleanup site: a stream dropped before completion removes its entry and sends Periphery the same terminal error item the interactive terminal already uses on client disconnect, so the existing `terminal_channels().remove` path cancels the forwarder. No new wire message. The map entry is also removed when the initial send to Periphery fails, since no stream exists to drop on that path.

### 2. `ExecuteTerminal` never registered for cancellation

`ConnectTerminal` registers a `TerminalChannel` with a `CancellationToken` and selects on it. `ExecuteTerminal` did neither, so nothing in the process could stop its forwarding task and it outlived Core's knowledge of the channel. It now mirrors the sibling: register the channel, select on the terminal's token and the channel's token, deregister on every exit.

The loop also ends the stream with `send_terminal_exited` when the terminal dies rather than leaving Core's body open, bounds the wait for the `Begin` trigger at 30s, and removes the trigger entry when that wait gives up (`TerminalTriggers::recv` only removes it on success).

### 3. A killed command's output was thrown away

`run_command` dropped the `wait_with_output()` future when the timeout or cancel branch won, so everything already printed was lost and `from_err_message` reported `stdout: ""`. The future is now pinned and re-awaited for up to 3s after the kill; the captured output is kept, the kill reason is appended to stderr and the status is set to failure. This applies to every existing caller that passes a timeout or cancel token, and not only Actions.

### What this does not do

It does not fix the `No response channel found` spam in #1392. That is Periphery's request keepalive against Core's `responses` map, your own second item on that issue. The `START_OF_OUTPUT` wait in `setup_execute_command_on_terminal` also stays unbounded.

### Verification

`cargo check` on the touched crates, `cargo test` and `cargo fmt --check` clean. Two tests, each confirmed to fail without its fix:

- `timeout_preserves_output` (`lib/command`) fails with `stdout: ""`.
- `cancelled_terminal_still_forwards_buffered_output` (`bin/periphery`) delivers 1 of 302 messages with the cancellation check at the top of the loop, and 104 of 302 without `unconstrained` on the read. A cancelled token is not budget-aware, so mid-drain it beats a read that has spent the task's cooperative budget, and takes the exit code with it.

The Core and Periphery changes have no runtime test against a live pair. Separately, #1563 adds a user-set execution timeout for Actions; it depends on the third change here to produce a usable log when it fires. Happy to split this into the `lib/command` half and the terminal half if you would rather review them separately.
