### PR TITLE
Added 'public_ip' as an option for periphery configuration

### DIFF
--- a/bin/periphery/src/config.rs
+++ b/bin/periphery/src/config.rs
@@ -117,6 +117,9 @@ pub fn periphery_config() -> &'static PeripheryConfig {
       disable_container_terminals: env
         .periphery_disable_container_terminals
         .unwrap_or(config.disable_container_terminals),
+      public_ip: env
+        .periphery_public_ip
+        .unwrap_or(config.public_ip),
       stats_polling_rate: env
         .periphery_stats_polling_rate
         .unwrap_or(config.stats_polling_rate),

--- a/bin/periphery/src/state.rs
+++ b/bin/periphery/src/state.rs
@@ -331,6 +331,11 @@ pub async fn host_public_ip() -> Option<&'static String> {
   static PUBLIC_IPS: OnceCell<Option<String>> = OnceCell::const_new();
   PUBLIC_IPS
     .get_or_init(|| async {
+      let public_ip = periphery_config().public_ip.trim();
+      if !public_ip.is_empty() {
+        return Some(public_ip.to_string());
+      }
+
       resolve_host_public_ip()
         .await
         .inspect_err(|e| {

--- a/client/core/rs/src/entities/config/periphery.rs
+++ b/client/core/rs/src/entities/config/periphery.rs
@@ -181,6 +181,8 @@ pub struct Env {
   /// Override `disable_container_terminals`
   #[serde(alias = "periphery_disable_container_exec")]
   pub periphery_disable_container_terminals: Option<bool>,
+  /// Override `public_ip`
+  pub periphery_public_ip: Option<String>,
   /// Override `stats_polling_rate`
   pub periphery_stats_polling_rate: Option<Timelength>,
   /// Override `container_stats_polling_rate`
@@ -378,6 +380,13 @@ pub struct PeripheryConfig {
   /// Default: false
   #[serde(default, alias = "disable_container_exec")]
   pub disable_container_terminals: bool,
+  
+  /// The public IP reported for the host.
+  /// If empty, Periphery resolves the IP by querying the OpenDNS resolvers.
+  /// When set, the lookup is skipped entirely.
+  /// Default: empty
+  #[serde(default)]
+  pub public_ip: String,
 
   /// The rate at which the system stats will be polled to update the cache.
   /// Options: https://docs.rs/komodo_client/latest/komodo_client/entities/enum.Timelength.html
@@ -484,6 +493,7 @@ impl Default for PeripheryConfig {
       default_terminal_command: default_default_terminal_command(),
       disable_terminals: Default::default(),
       disable_container_terminals: Default::default(),
+      public_ip: Default::default(),
       stats_polling_rate: default_stats_polling_rate(),
       container_stats_polling_rate:
         default_container_stats_polling_rate(),
@@ -535,6 +545,7 @@ impl PeripheryConfig {
       default_terminal_command: self.default_terminal_command.clone(),
       disable_terminals: self.disable_terminals,
       disable_container_terminals: self.disable_container_terminals,
+      public_ip: self.public_ip.clone(),
       stats_polling_rate: self.stats_polling_rate,
       container_stats_polling_rate: self.container_stats_polling_rate,
       legacy_compose_cli: self.legacy_compose_cli,

--- a/client/core/rs/src/entities/config/periphery.rs
+++ b/client/core/rs/src/entities/config/periphery.rs
@@ -380,7 +380,7 @@ pub struct PeripheryConfig {
   /// Default: false
   #[serde(default, alias = "disable_container_exec")]
   pub disable_container_terminals: bool,
-  
+
   /// The public IP reported for the host.
   /// If empty, Periphery resolves the IP by querying the OpenDNS resolvers.
   /// When set, the lookup is skipped entirely.

--- a/config/periphery.config.toml
+++ b/config/periphery.config.toml
@@ -75,7 +75,7 @@ disable_terminals = false
 disable_container_terminals = false
 
 ## The public IP reported for this host, shown on the Server page.
-## By default Periphery resolves this by querying the OpenDNS resolvers
+## By default Periphery resolves this by querying the OpenDNS resolvers.
 ## When set, the lookup is skipped entirely.
 ## Env: PERIPHERY_PUBLIC_IP
 ## Default: empty

--- a/config/periphery.config.toml
+++ b/config/periphery.config.toml
@@ -74,6 +74,13 @@ disable_terminals = false
 ## Default: false
 disable_container_terminals = false
 
+## The public IP reported for this host, shown on the Server page.
+## By default Periphery resolves this by querying the OpenDNS resolvers
+## When set, the lookup is skipped entirely.
+## Env: PERIPHERY_PUBLIC_IP
+## Default: empty
+public_ip = ""
+
 ## How often Periphery polls the host for system stats, like CPU / memory usage.
 ## To effectively disable polling, set this to something like 1-hr.
 ## Env: PERIPHERY_STATS_POLLING_RATE


### PR DESCRIPTION
## Summary

Adds a `public_ip` option to Periphery (env: `PERIPHERY_PUBLIC_IP`) that
sets the host address explicitly instead of resolving it via OpenDNS.

## Why

Periphery discovers the host public IP by querying the OpenDNS resolvers.
On air-gapped/offline networks that query can't be executed, and it causes the 'Server'
page to show `Unknown IP` for the machine.

## Changes

| File | Change |
|---|---|
| `client/core/rs/src/entities/config/periphery.rs` | added support for `public_ip` |
| `bin/periphery/src/config.rs` | reads `public_ip` environment value, falling back to the config value|
| `bin/periphery/src/state.rs` | tries to get `public_ip` instead of querying the OpenDNS resolvers |
| `config/periphery.config.toml` | documented `public_ip` |


## Behavior

- Set -> the DNS lookup is skipped and the set value is used.
- Empty, whitespace, or unset -> existing OpenDNS behavior, unchanged.

Quick note: This change is cosmetic only. The `public_ip` value isn't used in any place other than the 'Server' tab.


## Testing

- `cargo build` - succeeds.
- `cargo test` - succeeds.
- `rustfmt --check` - succeeds.
- With `PERIPHERY_PUBLIC_IP` set as an environment variable, the Server page shows the configured
  value and doesn't try to send an OpenDNS query.
- With it unset, periphery uses OpenDNS, same as before.