### PR TITLE
Cancel build Git operations on server builders

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2464,6 +2464,7 @@ dependencies = [
  "komodo_client",
  "mogh_cache",
  "tokio",
+ "tokio-util",
 ]
 
 [[package]]

--- a/bin/core/src/api/execute/build.rs
+++ b/bin/core/src/api/execute/build.rs
@@ -260,6 +260,7 @@ impl Resolve<ExecuteArgs> for RunBuild {
         res = periphery
           .request(api::git::PullOrCloneRepo {
             args: repo.as_ref().map(Into::into).unwrap_or((&build).into()),
+            cancel_id: Some(build.id.clone()),
             git_token,
             environment: Default::default(),
             env_file_path: Default::default(),
@@ -270,6 +271,13 @@ impl Resolve<ExecuteArgs> for RunBuild {
           }) => res,
         _ = cancel.cancelled() => {
           debug!("Build cancelled during repo clone, cleaning up builder");
+          if let Err(e) = periphery.request(api::build::CancelBuild {
+            id: build.id.clone()
+          })
+          .await
+          .context("Failed to cancel git execution on Server") {
+            update.push_error_log("Cancel Git", format_serror(&e.into()));
+          }
           update.push_error_log("Build cancelled", String::from("Build cancelled during repo clone"));
           cleanup_builder_instance(periphery, cleanup_data, &mut update)
             .await;

--- a/bin/periphery/src/api/git.rs
+++ b/bin/periphery/src/api/git.rs
@@ -11,9 +11,11 @@ use periphery_client::api::git::{
 };
 use std::path::PathBuf;
 use tokio::fs;
+use tokio_util::sync::CancellationToken;
 
 use crate::{
   config::periphery_config, helpers::handle_post_repo_execution,
+  state::build_cancel_cache,
 };
 
 impl Resolve<crate::api::Args> for GetLatestCommit {
@@ -141,6 +143,7 @@ impl Resolve<crate::api::Args> for PullOrCloneRepo {
   ) -> anyhow::Result<PeripheryRepoExecutionResponse> {
     let PullOrCloneRepo {
       args,
+      cancel_id,
       git_token,
       environment,
       env_file_path,
@@ -153,8 +156,29 @@ impl Resolve<crate::api::Args> for PullOrCloneRepo {
     let token = crate::helpers::git_token(git_token, &args)?;
     let parent_dir = default_folder(args.default_folder)?;
 
-    let (res, cloned) =
-      git::pull_or_clone(args, &parent_dir, token).await?;
+    let cancel = cancel_id.as_ref().map(|id| {
+      let cancel = CancellationToken::new();
+      (id, cancel)
+    });
+    if let Some((id, cancel)) = &cancel {
+      build_cancel_cache()
+        .insert((*id).clone(), cancel.clone())
+        .await;
+    }
+
+    let result = git::pull_or_clone_with_cancel(
+      args,
+      &parent_dir,
+      token,
+      cancel.as_ref().map(|(_, token)| token.clone()),
+    )
+    .await;
+
+    if let Some((id, _)) = &cancel {
+      build_cancel_cache().remove(id).await;
+    }
+
+    let (res, cloned) = result?;
 
     handle_post_repo_execution(
       res,

--- a/bin/periphery/src/stack/mod.rs
+++ b/bin/periphery/src/stack/mod.rs
@@ -111,6 +111,7 @@ pub async fn pull_or_clone_stack(
   let git_token = crate::helpers::git_token(git_token, &args)?;
 
   PullOrCloneRepo {
+    cancel_id: None,
     args,
     git_token,
     // All the extra pull functions

--- a/bin/periphery/src/stack/write.rs
+++ b/bin/periphery/src/stack/write.rs
@@ -179,6 +179,7 @@ async fn write_stack_linked_repo<'a>(
     .await?
   } else {
     PullOrCloneRepo {
+      cancel_id: None,
       args,
       git_token,
       environment: repo.config.env_vars()?,
@@ -264,6 +265,7 @@ async fn write_stack_inline_repo<'a>(
     .await?
   } else {
     PullOrCloneRepo {
+      cancel_id: None,
       args,
       git_token,
       environment: Default::default(),

--- a/client/periphery/rs/src/api/git.rs
+++ b/client/periphery/rs/src/api/git.rs
@@ -72,6 +72,9 @@ pub struct PullRepo {
 #[error(anyhow::Error)]
 pub struct PullOrCloneRepo {
   pub args: RepoExecutionArgs,
+  /// Optional id used to cancel the git operation through `CancelBuild`.
+  #[serde(default)]
+  pub cancel_id: Option<String>,
   /// Override git token with one sent from core.
   pub git_token: Option<String>,
   #[serde(default)]

--- a/lib/git/Cargo.toml
+++ b/lib/git/Cargo.toml
@@ -14,3 +14,4 @@ mogh_cache.workspace = true
 #
 anyhow.workspace = true
 tokio.workspace = true
+tokio-util.workspace = true

--- a/lib/git/src/clone.rs
+++ b/lib/git/src/clone.rs
@@ -7,6 +7,7 @@ use komodo_client::entities::{
   RepoExecutionArgs, RepoExecutionResponse, all_logs_success,
   update::Log,
 };
+use tokio_util::sync::CancellationToken;
 
 use crate::{check_installed, get_commit_hash_log};
 
@@ -20,6 +21,19 @@ pub async fn clone<T>(
   clone_args: T,
   root_repo_dir: &Path,
   access_token: Option<String>,
+) -> anyhow::Result<RepoExecutionResponse>
+where
+  T: Into<RepoExecutionArgs> + std::fmt::Debug,
+{
+  clone_with_cancel(clone_args, root_repo_dir, access_token, None)
+    .await
+}
+
+pub async fn clone_with_cancel<T>(
+  clone_args: T,
+  root_repo_dir: &Path,
+  access_token: Option<String>,
+  cancel: Option<CancellationToken>,
 ) -> anyhow::Result<RepoExecutionResponse>
 where
   T: Into<RepoExecutionArgs> + std::fmt::Debug,
@@ -75,7 +89,7 @@ where
   let mut log = run_komodo_standard_command(
     "Clone Repo",
     command,
-    CommandOptions::default(),
+    CommandOptions::default().cancel(cancel.clone()),
   )
   .await;
 
@@ -95,7 +109,9 @@ where
     let reset_log = run_komodo_standard_command(
       "set commit",
       format!("git reset --hard {commit}",),
-      CommandOptions::default().path(res.path.as_path()),
+      CommandOptions::default()
+        .path(res.path.as_path())
+        .cancel(cancel),
     )
     .await;
     res.logs.push(reset_log);

--- a/lib/git/src/init.rs
+++ b/lib/git/src/init.rs
@@ -5,6 +5,7 @@ use formatting::format_serror;
 use komodo_client::entities::{
   RepoExecutionArgs, all_logs_success, update::Log,
 };
+use tokio_util::sync::CancellationToken;
 
 use crate::check_installed;
 
@@ -13,6 +14,23 @@ pub async fn init_folder_as_repo(
   args: &RepoExecutionArgs,
   access_token: Option<&str>,
   logs: &mut Vec<Log>,
+) {
+  init_folder_as_repo_with_cancel(
+    folder_path,
+    args,
+    access_token,
+    logs,
+    None,
+  )
+  .await
+}
+
+pub async fn init_folder_as_repo_with_cancel(
+  folder_path: &Path,
+  args: &RepoExecutionArgs,
+  access_token: Option<&str>,
+  logs: &mut Vec<Log>,
+  cancel: Option<CancellationToken>,
 ) {
   if let Err(e) = check_installed().await {
     logs.push(Log::error("Git Init", format_serror(&e.into())));
@@ -23,7 +41,9 @@ pub async fn init_folder_as_repo(
   let init_repo = run_komodo_standard_command(
     "Git Init",
     "git init",
-    CommandOptions::default().path(folder_path),
+    CommandOptions::default()
+      .path(folder_path)
+      .cancel(cancel.clone()),
   )
   .await;
   logs.push(init_repo);
@@ -44,7 +64,9 @@ pub async fn init_folder_as_repo(
   let mut set_remote = run_komodo_standard_command(
     "Add git remote",
     format!("git remote add origin {repo_url}"),
-    CommandOptions::default().path(folder_path),
+    CommandOptions::default()
+      .path(folder_path)
+      .cancel(cancel.clone()),
   )
   .await;
   // Sanitize the output
@@ -62,7 +84,7 @@ pub async fn init_folder_as_repo(
   let init_repo = run_komodo_standard_command(
     "Set Branch",
     format!("git switch -c {}", args.branch),
-    CommandOptions::default().path(folder_path),
+    CommandOptions::default().path(folder_path).cancel(cancel),
   )
   .await;
   if !init_repo.success {

--- a/lib/git/src/lib.rs
+++ b/lib/git/src/lib.rs
@@ -15,12 +15,12 @@ mod pull;
 mod pull_or_clone;
 
 pub use crate::{
-  clone::clone,
+  clone::{clone, clone_with_cancel},
   commit::{commit_all, commit_file, write_commit_file},
   init::init_folder_as_repo,
   installed::check_installed,
-  pull::pull,
-  pull_or_clone::pull_or_clone,
+  pull::{pull, pull_with_cancel},
+  pull_or_clone::{pull_or_clone, pull_or_clone_with_cancel},
 };
 
 pub async fn get_commit_hash_info(

--- a/lib/git/src/pull.rs
+++ b/lib/git/src/pull.rs
@@ -10,6 +10,7 @@ use komodo_client::entities::{
   komodo_timestamp, update::Log,
 };
 use mogh_cache::TimeoutCache;
+use tokio_util::sync::CancellationToken;
 
 use crate::{check_installed, get_commit_hash_log};
 
@@ -31,6 +32,19 @@ pub async fn pull<T>(
   clone_args: T,
   root_repo_dir: &Path,
   access_token: Option<String>,
+) -> anyhow::Result<RepoExecutionResponse>
+where
+  T: Into<RepoExecutionArgs> + std::fmt::Debug,
+{
+  pull_with_cancel(clone_args, root_repo_dir, access_token, None)
+    .await
+}
+
+pub async fn pull_with_cancel<T>(
+  clone_args: T,
+  root_repo_dir: &Path,
+  access_token: Option<String>,
+  cancel: Option<CancellationToken>,
 ) -> anyhow::Result<RepoExecutionResponse>
 where
   T: Into<RepoExecutionArgs> + std::fmt::Debug,
@@ -64,11 +78,12 @@ where
     // Check for '.git' path to see if the folder is initialized as a git repo
     let dot_git_path = res.path.join(".git");
     if !dot_git_path.exists() {
-      crate::init::init_folder_as_repo(
+      crate::init::init_folder_as_repo_with_cancel(
         &res.path,
         &args,
         access_token.as_deref(),
         &mut res.logs,
+        cancel.clone(),
       )
       .await;
       if !all_logs_success(&res.logs) {
@@ -80,7 +95,9 @@ where
     let mut set_remote = run_komodo_standard_command(
       "Set Git Remote",
       format!("git remote set-url origin {repo_url}"),
-      CommandOptions::default().path(res.path.as_ref()),
+      CommandOptions::default()
+        .path(res.path.as_ref())
+        .cancel(cancel.clone()),
     )
     .await;
     // Sanitize the output
@@ -101,7 +118,9 @@ where
     let fetch = run_komodo_standard_command(
       "Git Fetch",
       "git fetch --all --prune",
-      CommandOptions::default().path(res.path.as_ref()),
+      CommandOptions::default()
+        .path(res.path.as_ref())
+        .cancel(cancel.clone()),
     )
     .await;
     if !fetch.success {
@@ -112,7 +131,9 @@ where
     let checkout = run_komodo_standard_command(
       "Checkout branch",
       format!("git checkout -f {}", args.branch),
-      CommandOptions::default().path(res.path.as_ref()),
+      CommandOptions::default()
+        .path(res.path.as_ref())
+        .cancel(cancel.clone()),
     )
     .await;
     res.logs.push(checkout);
@@ -123,7 +144,9 @@ where
     let pull_log = run_komodo_standard_command(
       "Git pull",
       format!("git pull --rebase --force origin {}", args.branch),
-      CommandOptions::default().path(res.path.as_ref()),
+      CommandOptions::default()
+        .path(res.path.as_ref())
+        .cancel(cancel.clone()),
     )
     .await;
     res.logs.push(pull_log);
@@ -135,7 +158,9 @@ where
       let reset_log = run_komodo_standard_command(
         "Set commit",
         format!("git reset --hard {commit}"),
-        CommandOptions::default().path(res.path.as_ref()),
+        CommandOptions::default()
+          .path(res.path.as_ref())
+          .cancel(cancel),
       )
       .await;
       res.logs.push(reset_log);

--- a/lib/git/src/pull_or_clone.rs
+++ b/lib/git/src/pull_or_clone.rs
@@ -3,6 +3,7 @@ use std::path::Path;
 use komodo_client::entities::{
   RepoExecutionArgs, RepoExecutionResponse,
 };
+use tokio_util::sync::CancellationToken;
 
 /// This is a mix of clone / pull.
 ///   - If the folder doesn't exist, it will clone the repo.
@@ -18,16 +19,39 @@ pub async fn pull_or_clone<T>(
 where
   T: Into<RepoExecutionArgs> + std::fmt::Debug,
 {
+  pull_or_clone_with_cancel(
+    clone_args,
+    root_repo_dir,
+    access_token,
+    None,
+  )
+  .await
+}
+
+pub async fn pull_or_clone_with_cancel<T>(
+  clone_args: T,
+  root_repo_dir: &Path,
+  access_token: Option<String>,
+  cancel: Option<CancellationToken>,
+) -> anyhow::Result<(RepoExecutionResponse, bool)>
+where
+  T: Into<RepoExecutionArgs> + std::fmt::Debug,
+{
   let args: RepoExecutionArgs = clone_args.into();
   let folder_path = args.path(root_repo_dir);
 
   if folder_path.exists() {
-    crate::pull(args, root_repo_dir, access_token)
+    crate::pull_with_cancel(args, root_repo_dir, access_token, cancel)
       .await
       .map(|r| (r, false))
   } else {
-    crate::clone(args, root_repo_dir, access_token)
-      .await
-      .map(|r| (r, true))
+    crate::clone_with_cancel(
+      args,
+      root_repo_dir,
+      access_token,
+      cancel,
+    )
+    .await
+    .map(|r| (r, true))
   }
 }


### PR DESCRIPTION
## What changed

- Propagate a Build-specific cancellation id into the Periphery `PullOrCloneRepo` request.
- Register a cancellation token while Build repository operations run.
- Pass that token to clone, fetch, checkout, pull, and reset commands through `CommandOptions`.
- Ask Periphery to cancel the registered Git process group when Core receives `CancelBuild` during the repository stage.
- Preserve the existing non-cancellable Git APIs for other callers.

## Why

The v2.3.0 cancellation flow explicitly cancels the Periphery image-build command, but cancellation during the earlier clone/pull stage only stops Core from awaiting the request. The Git process group can therefore survive after the Build update has been finalized, leaving actual host state inconsistent with Komodo's action state.

This was reproduced with a stalled HTTPS `git pull`, which left `git remote-https` and `git-remote-https` running after cancellation.

Closes #1579. Follow-up to #148.

## Validation

- `cargo fmt --all -- --check`
- `cargo check -p git -p periphery_client -p komodo_periphery -p komodo_core`
- `cargo test -p command -p git -p periphery_client`
