### PR TITLE
fix(sync): do not blank a ResourceTarget id when the lookup misses

### DIFF
--- a/bin/core/src/sync/replace_ids.rs
+++ b/bin/core/src/sync/replace_ids.rs
@@ -191,17 +191,21 @@ impl ReplaceIds for Procedure {
 /// Replaces the inner ids of [ResourceTarget] variants with the
 /// referenced resource's name, looking each up in [AllResourcesById].
 /// The `System` variant carries no id and is a no-op.
+///
+/// A failed lookup leaves the id UNCHANGED, and must not blank it.
+/// [ResourceTarget] is adjacently tagged (`tag = "type", content = "id"`) and
+/// `TOML_PRETTY_OPTIONS` sets `skip_empty_string`, so an empty id is omitted
+/// from the emitted table entirely, producing `{ type = "Stack" }`. That cannot
+/// be deserialized back, so every later sync of the file fails to parse.
 macro_rules! replace_resource_target_ids {
   ($target:expr, $all:expr, { $( $variant:ident => $field:ident ),* $(,)? }) => {
     match $target {
       komodo_client::entities::ResourceTarget::System(_) => {}
       $(
         komodo_client::entities::ResourceTarget::$variant(id) => {
-          *id = $all
-            .$field
-            .get(id)
-            .map(|r| r.name.clone())
-            .unwrap_or_default();
+          if let Some(resource) = $all.$field.get(id) {
+            *id = resource.name.clone();
+          }
         }
       )*
     }

--- a/bin/core/src/sync/replace_ids.rs
+++ b/bin/core/src/sync/replace_ids.rs
@@ -191,12 +191,6 @@ impl ReplaceIds for Procedure {
 /// Replaces the inner ids of [ResourceTarget] variants with the
 /// referenced resource's name, looking each up in [AllResourcesById].
 /// The `System` variant carries no id and is a no-op.
-///
-/// A failed lookup leaves the id UNCHANGED, and must not blank it.
-/// [ResourceTarget] is adjacently tagged (`tag = "type", content = "id"`) and
-/// `TOML_PRETTY_OPTIONS` sets `skip_empty_string`, so an empty id is omitted
-/// from the emitted table entirely, producing `{ type = "Stack" }`. That cannot
-/// be deserialized back, so every later sync of the file fails to parse.
 macro_rules! replace_resource_target_ids {
   ($target:expr, $all:expr, { $( $variant:ident => $field:ident ),* $(,)? }) => {
     match $target {


### PR DESCRIPTION
Managed-mode writeback can emit TOML that Komodo itself cannot parse, which leaves the sync broken until someone edits the file by hand. Hit this on a live deployment; the deploy pipeline stopped until I removed the offending line.

## What happens

A `Commit Sync` wrote this into `resources.toml`:

```toml
[[alerter]]
name = "Discord-stack-state"
[alerter.config]
alert_types = ["StackStateChange"]
resources = [{ type = "Stack" }]
```

Every read after that failed:

```
ERROR: failed to read resources from ".../resources.toml"
  1: failed to parse resource file contents
  2: TOML parse error at line 1548, column 14
     resources = [{ type = "Stack" }]
                  ^^^^^^^^^^^^^^^^^^
     missing field `id`
```

## Why

1. `replace_resource_target_ids!` rewrote each id to the resource name with `.map(|r| r.name.clone()).unwrap_or_default()`, so a missed lookup yields an empty `String`.
2. `ResourceTarget` is adjacently tagged, `#[serde(tag = "type", content = "id")]`, so `id` is required to deserialize.
3. `TOML_PRETTY_OPTIONS` sets `skip_empty_string: true`, so the empty `id` is omitted from the emitted table.

In my case the lookup missed because the file supplied the target by name, which is how every other synced reference is written, while the cache is keyed by id. Whether names should be accepted in that position is a separate question; this PR only stops a miss from corrupting the file.

## The change

Leave the id untouched when the lookup misses. On a hit nothing changes; on a miss the previous outcome was a file that cannot be read back.

`DeploymentImage::Build` has the same shape (`build_id` blanked, adjacently tagged) and is covered in #1584. The plain `String` fields nearby (`server_id`, `swarm_id`, `linked_repo`, `builder_id`) still parse when empty, so they are unaffected.

## Verification

`cargo check -p komodo_core` clean with no new warnings, `cargo fmt --check` clean. No test: the macro reads the global `all_resources_cache()` and `bin/core` has no test scaffolding for it.
