### PR TITLE
fix(sync): three ways a UserGroup sync loses a permission silently

### DIFF
--- a/bin/core/src/api/execute/sync.rs
+++ b/bin/core/src/api/execute/sync.rs
@@ -274,6 +274,7 @@ impl Resolve<ExecuteArgs> for RunSync {
       user_groups_to_create,
       user_groups_to_update,
       user_groups_to_delete,
+      dropped_permission_targets,
     ) = if match_resource_type.is_none()
       && match_resources.is_none()
       && sync.config.include_user_groups
@@ -303,6 +304,9 @@ impl Resolve<ExecuteArgs> for RunSync {
       && user_groups_to_create.is_empty()
       && user_groups_to_update.is_empty()
       && user_groups_to_delete.is_empty()
+      // A sync whose only finding is a dropped permission target still has
+      // something to say, so it must not exit as "nothing to do" here.
+      && dropped_permission_targets.is_empty()
       && variables_to_create.is_empty()
       && variables_to_update.is_empty()
       && variables_to_delete.is_empty()
@@ -432,13 +436,16 @@ impl Resolve<ExecuteArgs> for RunSync {
     } else {
       None
     };
-    if let Some((to_create, to_update, to_delete)) =
+    if let Some((to_create, to_update, to_delete, dropped_targets)) =
       user_group_updates
     {
       maybe_extend(
         &mut update.logs,
         crate::sync::user_groups::run_updates(
-          to_create, to_update, to_delete,
+          to_create,
+          to_update,
+          to_delete,
+          dropped_targets,
         )
         .await,
       );

--- a/bin/core/src/api/execute/sync.rs
+++ b/bin/core/src/api/execute/sync.rs
@@ -266,6 +266,10 @@ impl Resolve<ExecuteArgs> for RunSync {
     } else {
       Default::default()
     };
+    // Cloned because this early result is used ONLY for the no-changes check
+    // below. Applying it would be wrong: see the recompute further down, next to
+    // where the UserGroups are actually applied.
+    let user_groups_toml = resources.user_groups.clone();
     let (
       user_groups_to_create,
       user_groups_to_update,
@@ -335,15 +339,6 @@ impl Resolve<ExecuteArgs> for RunSync {
       )
       .await,
     );
-    maybe_extend(
-      &mut update.logs,
-      crate::sync::user_groups::run_updates(
-        user_groups_to_create,
-        user_groups_to_update,
-        user_groups_to_delete,
-      )
-      .await,
-    );
 
     maybe_extend(
       &mut update.logs,
@@ -399,6 +394,55 @@ impl Resolve<ExecuteArgs> for RunSync {
       &mut update.logs,
       Procedure::execute_sync_updates(procedure_deltas).await,
     );
+
+    // Depends on everything: a UserGroup permission names a resource, so its
+    // targets can only be resolved once this sync's own resources exist.
+    //
+    // Recomputed rather than reusing the result from above, because that one
+    // expanded the permission targets against a resource cache captured BEFORE
+    // this sync created anything. `expand_user_group_permissions` keeps only the
+    // targets it can match in that cache, so a permission on a resource created
+    // by this same sync was silently dropped and the sync still reported success.
+    // `resource::create` refreshes the cache, so by here the targets resolve.
+    let user_group_updates = if match_resource_type.is_none()
+      && match_resources.is_none()
+      && sync.config.include_user_groups
+    {
+      match crate::sync::user_groups::get_updates_for_execution(
+        user_groups_toml,
+        delete,
+      )
+      .await
+      {
+        Ok(updates) => Some(updates),
+        // Deliberately not fatal. Every resource phase has already been
+        // applied by this point, so aborting here would skip the deploy cache
+        // and the sync's own `last_sync_ts` bookkeeping. Report and continue.
+        Err(e) => {
+          update.push_error_log(
+            "Update UserGroups",
+            format_serror(
+              &e.context("failed to compute UserGroup updates")
+                .into(),
+            ),
+          );
+          None
+        }
+      }
+    } else {
+      None
+    };
+    if let Some((to_create, to_update, to_delete)) =
+      user_group_updates
+    {
+      maybe_extend(
+        &mut update.logs,
+        crate::sync::user_groups::run_updates(
+          to_create, to_update, to_delete,
+        )
+        .await,
+      );
+    }
 
     // Execute the deploy cache
     deploy_from_cache(deploy_cache, &mut update.logs).await;

--- a/bin/core/src/api/execute/sync.rs
+++ b/bin/core/src/api/execute/sync.rs
@@ -266,9 +266,6 @@ impl Resolve<ExecuteArgs> for RunSync {
     } else {
       Default::default()
     };
-    // Cloned because this early result is used ONLY for the no-changes check
-    // below. Applying it would be wrong: see the recompute further down, next to
-    // where the UserGroups are actually applied.
     let user_groups_toml = resources.user_groups.clone();
     let (
       user_groups_to_create,
@@ -304,8 +301,6 @@ impl Resolve<ExecuteArgs> for RunSync {
       && user_groups_to_create.is_empty()
       && user_groups_to_update.is_empty()
       && user_groups_to_delete.is_empty()
-      // A sync whose only finding is a dropped permission target still has
-      // something to say, so it must not exit as "nothing to do" here.
       && dropped_permission_targets.is_empty()
       && variables_to_create.is_empty()
       && variables_to_update.is_empty()
@@ -399,16 +394,7 @@ impl Resolve<ExecuteArgs> for RunSync {
       Procedure::execute_sync_updates(procedure_deltas).await,
     );
 
-    // Depends on everything: a UserGroup permission names a resource, so its
-    // targets can only be resolved once this sync's own resources exist.
-    //
-    // Recomputed rather than reusing the result from above, because that one
-    // expanded the permission targets against a resource cache captured BEFORE
-    // this sync created anything. `expand_user_group_permissions` keeps only the
-    // targets it can match in that cache, so a permission on a resource created
-    // by this same sync was silently dropped and the sync still reported success.
-    // `resource::create` refreshes the cache, so by here the targets resolve.
-    let user_group_updates = if match_resource_type.is_none()
+    if match_resource_type.is_none()
       && match_resources.is_none()
       && sync.config.include_user_groups
     {
@@ -418,37 +404,25 @@ impl Resolve<ExecuteArgs> for RunSync {
       )
       .await
       {
-        Ok(updates) => Some(updates),
-        // Deliberately not fatal. Every resource phase has already been
-        // applied by this point, so aborting here would skip the deploy cache
-        // and the sync's own `last_sync_ts` bookkeeping. Report and continue.
-        Err(e) => {
-          update.push_error_log(
-            "Update UserGroups",
-            format_serror(
-              &e.context("failed to compute UserGroup updates")
-                .into(),
-            ),
-          );
-          None
+        Ok((to_create, to_update, to_delete, dropped_targets)) => {
+          maybe_extend(
+            &mut update.logs,
+            crate::sync::user_groups::run_updates(
+              to_create,
+              to_update,
+              to_delete,
+              dropped_targets,
+            )
+            .await,
+          )
         }
+        Err(e) => update.push_error_log(
+          "Update UserGroups",
+          format_serror(
+            &e.context("failed to compute UserGroup updates").into(),
+          ),
+        ),
       }
-    } else {
-      None
-    };
-    if let Some((to_create, to_update, to_delete, dropped_targets)) =
-      user_group_updates
-    {
-      maybe_extend(
-        &mut update.logs,
-        crate::sync::user_groups::run_updates(
-          to_create,
-          to_update,
-          to_delete,
-          dropped_targets,
-        )
-        .await,
-      );
     }
 
     // Execute the deploy cache

--- a/bin/core/src/sync/user_groups.rs
+++ b/bin/core/src/sync/user_groups.rs
@@ -822,9 +822,9 @@ async fn run_update_permissions(
 /// A resource target that matches no existing resource expands to nothing and
 /// its permission is therefore never applied. Those are pushed to `dropped` so
 /// the caller can report them, because the alternative is a permission that the
-/// TOML declares, the sync reports success for, and nobody ever gets. System
-/// targets are excluded: they are not name matched, so no-match says nothing
-/// about them.
+/// TOML declares, the sync reports success for, and nobody ever gets. A System
+/// target is passed through untouched: it names no resource, so there is
+/// nothing to match it against.
 async fn expand_user_group_permissions(
   permissions: Vec<PermissionToml>,
   user_group: &str,
@@ -982,11 +982,15 @@ async fn expand_user_group_permissions(
           });
         expanded.extend(permissions);
       }
-      // Not reported here: a System target is not name matched, so the
-      // no-match wording would mislead. Its id is "system" rather than empty,
-      // so the guard above does not skip it, and this `continue` is what keeps
-      // it out of the no-match check below.
-      ResourceTargetVariant::System => continue,
+      // Passed through rather than name matched. A System target names no
+      // resource, so there is nothing to match it against, and dropping it
+      // here is what made the export / import round trip lossy: the export
+      // writes System permissions into the file, and a target missing from
+      // this list is later revoked by `to_remove`.
+      ResourceTargetVariant::System => {
+        expanded.push(permission);
+        continue;
+      }
     }
     if expanded.len() == before {
       dropped.push(format!(

--- a/bin/core/src/sync/user_groups.rs
+++ b/bin/core/src/sync/user_groups.rs
@@ -173,15 +173,20 @@ pub async fn get_updates_for_view(
       .permissions
       .retain(|p| p.level > PermissionLevel::None);
 
-    user_group.permissions =
-      expand_user_group_permissions(user_group.permissions)
-        .await
-        .with_context(|| {
-          format!(
-            "failed to expand user group {} permissions",
-            user_group.name
-          )
-        })?;
+    // Discarded on purpose. This function backs the sync VIEW, which is
+    // recomputed continuously, so reporting here would be noise rather than news.
+    user_group.permissions = expand_user_group_permissions(
+      user_group.permissions,
+      &user_group.name,
+      &mut Vec::new(),
+    )
+    .await
+    .with_context(|| {
+      format!(
+        "failed to expand user group {} permissions",
+        user_group.name
+      )
+    })?;
 
     let (_original_id, original) =
       match map.get(&user_group.name).cloned() {
@@ -222,6 +227,8 @@ pub async fn get_updates_for_view(
   Ok(diffs)
 }
 
+/// The fourth member is the permission targets that matched no existing
+/// resource. Their permissions are not applied, so [run_updates] reports them.
 pub async fn get_updates_for_execution(
   user_groups: Vec<UserGroupToml>,
   delete: bool,
@@ -229,6 +236,7 @@ pub async fn get_updates_for_execution(
   Vec<UserGroupToml>,
   Vec<UpdateItem>,
   Vec<DeleteItem>,
+  Vec<String>,
 )> {
   let map = find_collect(&db_client().user_groups, None, None)
     .await
@@ -248,6 +256,7 @@ pub async fn get_updates_for_execution(
   let mut to_create = Vec::<UserGroupToml>::new();
   let mut to_update = Vec::<UpdateItem>::new();
   let mut to_delete = Vec::<DeleteItem>::new();
+  let mut dropped = Vec::<String>::new();
 
   if delete {
     for user_group in map.values() {
@@ -261,7 +270,7 @@ pub async fn get_updates_for_execution(
   }
 
   if user_groups.is_empty() {
-    return Ok((to_create, to_update, to_delete));
+    return Ok((to_create, to_update, to_delete, dropped));
   }
 
   let id_to_user = find_collect(&db_client().users, None, None)
@@ -280,15 +289,18 @@ pub async fn get_updates_for_execution(
       .permissions
       .retain(|p| p.level > PermissionLevel::None);
 
-    user_group.permissions =
-      expand_user_group_permissions(user_group.permissions)
-        .await
-        .with_context(|| {
-          format!(
-            "Failed to expand user group {} permissions",
-            user_group.name
-          )
-        })?;
+    user_group.permissions = expand_user_group_permissions(
+      user_group.permissions,
+      &user_group.name,
+      &mut dropped,
+    )
+    .await
+    .with_context(|| {
+      format!(
+        "Failed to expand user group {} permissions",
+        user_group.name
+      )
+    })?;
 
     let original = match map.get(&user_group.name).cloned() {
       Some(original) => original,
@@ -472,7 +484,10 @@ pub async fn get_updates_for_execution(
     }
   }
 
-  Ok((to_create, to_update, to_delete))
+  dropped.sort_unstable();
+  dropped.dedup();
+
+  Ok((to_create, to_update, to_delete, dropped))
 }
 
 /// order permissions in deterministic way
@@ -495,16 +510,30 @@ pub async fn run_updates(
   to_create: Vec<UserGroupToml>,
   to_update: Vec<UpdateItem>,
   to_delete: Vec<DeleteItem>,
+  dropped_targets: Vec<String>,
 ) -> Option<Log> {
   if to_create.is_empty()
     && to_update.is_empty()
     && to_delete.is_empty()
+    && dropped_targets.is_empty()
   {
     return None;
   }
 
   let mut has_error = false;
   let mut log = String::from("running updates on UserGroups");
+
+  // Reported, not fatal. A target can match nothing because it names a
+  // resource that does not exist, or because a pattern legitimately matches
+  // nothing right now, and the sync cannot tell those apart. Either way the
+  // permission is NOT applied, which is the part a reader needs to know.
+  for target in dropped_targets {
+    log.push_str(&format!(
+      "\n{}: permission target matched no existing resource, so it was NOT applied | {}",
+      colored("WARN", Color::Red),
+      bold(&target)
+    ));
+  }
 
   // Create the non-existant user groups
   for user_group in to_create {
@@ -788,9 +817,18 @@ async fn run_update_permissions(
   }
 }
 
-/// Expands any regex defined targets into the full list
+/// Expands any regex defined targets into the full list.
+///
+/// A resource target that matches no existing resource expands to nothing and
+/// its permission is therefore never applied. Those are pushed to `dropped` so
+/// the caller can report them, because the alternative is a permission that the
+/// TOML declares, the sync reports success for, and nobody ever gets. System
+/// targets are excluded: they are not name matched, so no-match says nothing
+/// about them.
 async fn expand_user_group_permissions(
   permissions: Vec<PermissionToml>,
+  user_group: &str,
+  dropped: &mut Vec<String>,
 ) -> anyhow::Result<Vec<PermissionToml>> {
   let mut expanded =
     Vec::<PermissionToml>::with_capacity(permissions.capacity());
@@ -799,9 +837,16 @@ async fn expand_user_group_permissions(
   for permission in permissions {
     let (variant, id) = permission.target.extract_variant_id();
     if id.is_empty() {
+      // An id is a resource name or a regex over names, so an empty one
+      // matches nothing and the permission is dropped. Same outcome as the
+      // no-match check below, different cause, so it gets its own wording.
+      dropped.push(format!(
+        "user group: {user_group} | target: {variant} with an empty id"
+      ));
       continue;
     }
     let matcher = Matcher::new(id)?;
+    let before = expanded.len();
     match variant {
       ResourceTargetVariant::Swarm => {
         let permissions = all_resources
@@ -937,7 +982,16 @@ async fn expand_user_group_permissions(
           });
         expanded.extend(permissions);
       }
-      ResourceTargetVariant::System => {}
+      // Not reported here: a System target is not name matched, so the
+      // no-match wording would mislead. Its id is "system" rather than empty,
+      // so the guard above does not skip it, and this `continue` is what keeps
+      // it out of the no-match check below.
+      ResourceTargetVariant::System => continue,
+    }
+    if expanded.len() == before {
+      dropped.push(format!(
+        "user group: {user_group} | target: {variant} {id}"
+      ));
     }
   }
 

--- a/bin/core/src/sync/user_groups.rs
+++ b/bin/core/src/sync/user_groups.rs
@@ -173,8 +173,6 @@ pub async fn get_updates_for_view(
       .permissions
       .retain(|p| p.level > PermissionLevel::None);
 
-    // Discarded on purpose. This function backs the sync VIEW, which is
-    // recomputed continuously, so reporting here would be noise rather than news.
     user_group.permissions = expand_user_group_permissions(
       user_group.permissions,
       &user_group.name,
@@ -227,8 +225,6 @@ pub async fn get_updates_for_view(
   Ok(diffs)
 }
 
-/// The fourth member is the permission targets that matched no existing
-/// resource. Their permissions are not applied, so [run_updates] reports them.
 pub async fn get_updates_for_execution(
   user_groups: Vec<UserGroupToml>,
   delete: bool,
@@ -523,10 +519,6 @@ pub async fn run_updates(
   let mut has_error = false;
   let mut log = String::from("running updates on UserGroups");
 
-  // Reported, not fatal. A target can match nothing because it names a
-  // resource that does not exist, or because a pattern legitimately matches
-  // nothing right now, and the sync cannot tell those apart. Either way the
-  // permission is NOT applied, which is the part a reader needs to know.
   for target in dropped_targets {
     log.push_str(&format!(
       "\n{}: permission target matched no existing resource, so it was NOT applied | {}",
@@ -817,14 +809,7 @@ async fn run_update_permissions(
   }
 }
 
-/// Expands any regex defined targets into the full list.
-///
-/// A resource target that matches no existing resource expands to nothing and
-/// its permission is therefore never applied. Those are pushed to `dropped` so
-/// the caller can report them, because the alternative is a permission that the
-/// TOML declares, the sync reports success for, and nobody ever gets. A System
-/// target is passed through untouched: it names no resource, so there is
-/// nothing to match it against.
+/// Expands any regex defined targets into the full list
 async fn expand_user_group_permissions(
   permissions: Vec<PermissionToml>,
   user_group: &str,
@@ -837,9 +822,6 @@ async fn expand_user_group_permissions(
   for permission in permissions {
     let (variant, id) = permission.target.extract_variant_id();
     if id.is_empty() {
-      // An id is a resource name or a regex over names, so an empty one
-      // matches nothing and the permission is dropped. Same outcome as the
-      // no-match check below, different cause, so it gets its own wording.
       dropped.push(format!(
         "user group: {user_group} | target: {variant} with an empty id"
       ));
@@ -982,11 +964,6 @@ async fn expand_user_group_permissions(
           });
         expanded.extend(permissions);
       }
-      // Passed through rather than name matched. A System target names no
-      // resource, so there is nothing to match it against, and dropping it
-      // here is what made the export / import round trip lossy: the export
-      // writes System permissions into the file, and a target missing from
-      // this list is later revoked by `to_remove`.
       ResourceTargetVariant::System => {
         expanded.push(permission);
         continue;


### PR DESCRIPTION
A sync that creates a resource and a UserGroup permission on that same resource creates the group, adds its users, reports success, and applies no permission. Hit this on a live deployment: a service user was denied `Execute` on an Action the TOML grants it, and a second run applied it. Tracing that turned up two more ways the same path loses a permission silently. Three commits, readable one by one; commit 3 is independent of the other two.

## Commit 1: apply UserGroups after resources, not before

`user_groups::run_updates` ran in the apply block under `// No deps`, ahead of every resource phase, and `user_groups::get_updates_for_execution` ran in the pre-computation block. That is where `expand_user_group_permissions` resolves each permission target through `Matcher` against `all_resources_cache()`, keeping only the targets it can match. A target naming a resource the same sync is about to create expands to nothing and is dropped with no error. The apply block already documents that later phases may depend on earlier ones, and `Procedure` is last for that reason; a UserGroup permission names a resource, so UserGroups belong there too.

The phase moves after `Procedure` and recomputes its deltas there, since the pre-computation expanded against the pre-sync cache (`resource::create` refreshes it). The early computation is kept only to feed the existing no-changes exit, which is why the TOML is cloned. The recompute does not propagate its error: every resource phase has been applied by then, and a `?` would add a mid-sync abort that skips `deploy_from_cache` and the `last_sync_ts` bookkeeping. It logs into the update instead, as `run_updates` already does.

Cost: one extra `get_updates_for_execution` per sync when `include_user_groups` is on (a `find_collect` over user_groups, one over users, one `ListUserTargetPermissions` per group). If you would rather avoid the second pass, the expansion could move inside `run_updates`; that is a larger change and I did not want to guess.

Interactions checked: with `delete = true`, `delete_all_permissions_on_resource` purges a removed resource's rows in the same phase, so the recompute reaches the same end state the old order did by granting then deleting. A failing resource phase still runs the UserGroup phase afterwards, as before. Wildcard targets now expand over resources created by the same sync and no longer emit doomed updates against ones it deleted.

## Commit 2: report permission targets that match nothing

The remaining case is a target that is not resolvable at all (a typo, a renamed resource, a pattern matching nothing). It was dropped and the sync was green. The expansion now collects each target that expanded to nothing, and `run_updates` prints one `WARN` line per unique target into the UserGroups log, naming the group and the target. An empty target id is reported the same way. Reported rather than fatal, because a pattern that legitimately matches nothing right now is supported configuration and the sync cannot tell the two apart.

Details worth your attention:

- The reported list comes from the post-resource recompute, so a target naming a resource this sync just created is not reported. The pre-resource list only feeds the `RunSync` no-changes gate, so a sync whose only finding is a dropped target no longer exits "nothing to do" before the report is written. That run now proceeds through the apply block as a no-op and updates `last_sync_ts` / `last_sync_hash`; displayed sync state and the pending-updates alert derive from view-path data and are unaffected. This is the one behavior change beyond the log line.
- Execute-tab visibility comes from the view path, which discards this list, so a sync whose sole finding is a bad target does not grow an Execute button to surface it. Fixing that means an informational field on `ResourceSyncInfo`; say the word if you want it.
- System targets are excluded from the check; they are not name matched.
- `get_updates_for_execution` now returns a 4-tuple. A struct would read better (precedent in `SyncDeltas`); I kept the tuple to hold the diff to the bug.

## Commit 3: stop the sync revoking System permissions it exported itself

`convert_user_groups` writes a group's System permissions into the file, `expand_user_group_permissions` drops every System target on the way back in, and `to_remove` sets every original permission missing from the incoming list to `PermissionLevel::None`. So syncing back a file Komodo itself exported revokes the group's System permissions, and the view shows a permission removal nobody asked for on every refresh. The fix is pass-through: a System target names no resource, so nothing needs expanding.

Severity: this restores round-trip fidelity, not access. `get_user_permission_on_target` returns `None` for System unconditionally, so the permission grants nothing today either way; what changes is that the sync stops deleting a row a user created and stops rendering an unsettleable diff. The symmetric alternative is to filter System out of `convert_user_groups` and make `to_remove` skip System; I picked pass-through because it is one branch and keeps export and import agreeing.

## Verification

`cargo check -p komodo_core` and `cargo check -p komodo_core --tests` clean with no new warnings, `cargo fmt --check` clean. Reproduced the original failure and the fix against a live Core (a sync creating an Action plus a group granting `Execute` on it: permission missing before, applied after). No test added: `bin/core` has no test module and these paths need a database and the resource cache. `WARN` with `Color::Red` follows the precedent in `sync/file.rs`.
