### PR TITLE
fix(client): sleep between polls in the blocking poll helper

### DIFF
--- a/client/core/rs/src/lib.rs
+++ b/client/core/rs/src/lib.rs
@@ -211,6 +211,10 @@ impl KomodoClient {
       if update.status == entities::update::UpdateStatus::Complete {
         return Ok(update);
       }
+      // Match the async variant's interval. Without this the loop hammers
+      // GetUpdate as fast as the network allows for the whole duration of the
+      // execution, which for a Stack deploy is minutes of hot looping.
+      std::thread::sleep(Duration::from_millis(500));
     }
   }
 }

--- a/client/core/rs/src/lib.rs
+++ b/client/core/rs/src/lib.rs
@@ -211,9 +211,6 @@ impl KomodoClient {
       if update.status == entities::update::UpdateStatus::Complete {
         return Ok(update);
       }
-      // Match the async variant's interval. Without this the loop hammers
-      // GetUpdate as fast as the network allows for the whole duration of the
-      // execution, which for a Stack deploy is minutes of hot looping.
       std::thread::sleep(Duration::from_millis(500));
     }
   }

--- a/client/core/ts/src/lib.ts
+++ b/client/core/ts/src/lib.ts
@@ -381,7 +381,7 @@ export function KomodoClient(url: string, options: InitOptions) {
      * ```
      *
      * NOTE. These calls return immediately when the update is created, NOT when the execution task finishes.
-     * To have the call only return when the task finishes, use [execute_and_poll_until_complete].
+     * To have the call only return when the task finishes, use [execute_and_poll].
      *
      * https://docs.rs/komodo_client/latest/komodo_client/api/execute/index.html
      */


### PR DESCRIPTION
Two small defects in the execute-then-poll helpers.

## 1. The blocking poll helper busy-loops

`poll_update_until_complete` under `#[cfg(feature = "blocking")]` has no delay in its loop, so it re-issues `GetUpdate` as fast as the network allows for the whole execution. For a Stack deploy that is minutes of hot looping against Core. The async variant already sleeps 500 ms between polls; this adds the matching `std::thread::sleep`.

## 2. A doc comment points at a function that does not exist

`client/core/ts/src/lib.ts`, on `execute`, says to use `[execute_and_poll_until_complete]` to block until the task finishes. The exported function is `execute_and_poll`.

## Verification

`cargo check -p komodo_client --features blocking` clean (it also clears the `unused import: Duration` warning the cfg'd-out variant left), `cargo fmt --check` clean.
