### PR TITLE
fix(docs): resource_poll_interval's doc comment claims the wrong default

### DIFF
--- a/client/core/rs/src/entities/config/core.rs
+++ b/client/core/rs/src/entities/config/core.rs
@@ -707,7 +707,7 @@ pub struct CoreConfig {
   // ==================
   /// Interval at which to poll resources for any updates / automated actions.
   /// Options: `15-sec`, `1-min`, `5-min`, `15-min`, `1-hr`
-  /// Default: `5-min`.  
+  /// Default: `1-hr`.
   #[serde(default = "default_poll_interval")]
   pub resource_poll_interval: Timelength,
 


### PR DESCRIPTION
## Summary

`resource_poll_interval`'s doc comment says "Default: `5-min`.", but `default_poll_interval()` (in the same file) actually returns `Timelength::OneHour`. The two have disagreed since the field was introduced.

Anyone relying on the doc comment rather than reading `default_poll_interval()` directly will assume resources are polled 12x more often than they actually are, and could misread a genuinely-normal gap of up to an hour (with no corresponding log output, since the refresh loop only logs on failure) as a stuck/wedged sync.

## What changed

One line: the doc comment now says `Default: 1-hr.`, matching the actual code. Not touching the default value itself — that's a behavior decision for the maintainers, this is just correcting the documentation to match what already ships.

## Test plan
- Doc-comment-only change, no behavior affected.