### PR TITLE
fix: Pin compatible Docker clients in Periphery images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,26 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  periphery-docker-clients:
+    name: Periphery Docker Clients
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check compatible Docker client versions
+        run: |
+          docker build --tag periphery-docker-clients-test --file - . <<'EOF'
+          FROM debian:trixie-slim
+          COPY bin/periphery/debian-deps.sh /tmp/debian-deps.sh
+          RUN sh /tmp/debian-deps.sh
+          EOF
+
+          docker run --rm periphery-docker-clients-test sh -eu -c '
+            docker --version | grep -Eq "^Docker version 28\."
+            docker compose version | grep -Eq "^Docker Compose version v?5\.0\."
+          '
+
   build:
     name: Build & Test
     runs-on: ubuntu-latest

--- a/bin/periphery/debian-deps.sh
+++ b/bin/periphery/debian-deps.sh
@@ -17,7 +17,10 @@ echo \
 apt-get update
 
 # apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
-apt-get install -y docker-ce-cli docker-buildx-plugin docker-compose-plugin
+apt-get install -y --allow-downgrades \
+  docker-ce-cli='5:28.*' \
+  docker-buildx-plugin \
+  docker-compose-plugin='5.0.*'
 
 rm -rf /var/lib/apt/lists/*
 
@@ -25,4 +28,3 @@ rm -rf /var/lib/apt/lists/*
 curl -sS https://starship.rs/install.sh | sh -s -- --yes --bin-dir /usr/local/bin
 echo 'export STARSHIP_CONFIG=/starship.toml' >> /root/.bashrc
 echo 'eval "$(starship init bash)"' >> /root/.bashrc
-


### PR DESCRIPTION
Constrain `docker-ce-cli` to the 28.x package line and `docker-compose-plugin` to the 5.0.x line in the shared Periphery dependency installer, while leaving the unrelated buildx package unchanged. Use apt's explicit version selection and downgrade support so all single-architecture, multi-architecture, and all-in-one Periphery Dockerfiles inherit the same compatible clients through their existing call to `debian-deps.sh`. Periphery container images currently install the newest `docker-ce-cli` and `docker-compose-plugin` packages from Docker's Debian repository. Docker CLI 29 and Compose 5.1 can fail against Docker Engine 27 when an IPv6 network gateway is returned with a CIDR suffix, causing stack restart, stop, destroy, deploy, and discovery operations to fail with `ParseAddr(.../64)`.

Build the dependency layer from `debian:trixie-slim` using `bin/periphery/debian-deps.sh`; installation succeeds while a newer package version is present in the configured Docker repository; Query `docker --version` after installation and verify the bundled CLI remains on the 28.x compatibility line.

Closes #1249
